### PR TITLE
Add support for `mounts` stanzas

### DIFF
--- a/examples/mount-example.yaml
+++ b/examples/mount-example.yaml
@@ -1,0 +1,11 @@
+---
+
+- step:
+    name: test
+    image: busybox
+    command: foo {parameters}
+    mounts:
+      - /foo:/bar
+      - source: /baz
+        destination: /quux
+        readonly: true

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if __name__ == '__main__':
     setuptools.setup(
         name='valohai-yaml',
         description='Valohai.yaml validation and parsing',
-        version='0.4',
+        version='0.5',
         url='https://github.com/valohai/valohai-yaml',
         author='Valohai',
         maintainer='Aarni Koskela',

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -3,6 +3,7 @@ from tests.utils import config_fixture
 example1_config = config_fixture('example1.yaml')
 example2_config = config_fixture('example2.yaml')
 boolean_param_config = config_fixture('flag-param-example.yaml')
+mount_config = config_fixture('mount-example.yaml')
 
 
 def test_parse_inputs(example2_config):
@@ -77,3 +78,8 @@ def test_boolean_param_parse(boolean_param_config):
     assert step.parameters['case-insensitive'].choices == (True, False)
     assert step.build_command({'case-insensitive': True}) == ['foo --case-insensitive']
     assert step.build_command({'case-insensitive': False}) == ['foo']
+
+
+def test_mount_parse(mount_config):
+    step = mount_config.steps['test']
+    assert len(step.mounts) == 2

--- a/valohai_yaml/objs/__init__.py
+++ b/valohai_yaml/objs/__init__.py
@@ -1,3 +1,4 @@
 from .config import Config  # noqa
+from .mount import Mount  # noqa
 from .parameter import Parameter  # noqa
 from .step import Step  # noqa

--- a/valohai_yaml/objs/mount.py
+++ b/valohai_yaml/objs/mount.py
@@ -1,0 +1,25 @@
+from six import string_types, text_type
+
+from .base import _SimpleObject
+
+
+class Mount(_SimpleObject):
+    def __init__(
+        self,
+        source,
+        destination,
+        readonly=False,
+    ):
+        self.source = source
+        self.destination = destination
+        self.readonly = bool(readonly)
+
+    @classmethod
+    def parse(cls, data):
+        if isinstance(data, string_types):
+            source, destination = text_type(data).split(':', 1)
+            data = {
+                'source': source,
+                'destination': destination,
+            }
+        return super(Mount, cls).parse(data)

--- a/valohai_yaml/objs/step.py
+++ b/valohai_yaml/objs/step.py
@@ -7,17 +7,21 @@ import six
 from valohai_yaml.commands import build_command
 
 from .input import Input
+from .mount import Mount
 from .parameter import Parameter
 
 
 class Step(object):
 
-    def __init__(self, name, image, command, parameters=(), inputs=(), outputs=()):
+    def __init__(self, name, image, command, parameters=(), inputs=(), outputs=(), mounts=()):
         self.name = name
         self.image = image
         self.command = command
 
         self.outputs = list(outputs)  # TODO: Improve handling
+
+        assert all(isinstance(m, Mount) for m in mounts)
+        self.mounts = list(mounts)
 
         assert all(isinstance(i, Input) for i in inputs)
         self.inputs = OrderedDict((input.name, input) for input in inputs)
@@ -30,6 +34,7 @@ class Step(object):
         kwargs = data.copy()
         kwargs['parameters'] = [Parameter.parse(p_data) for p_data in kwargs.pop('parameters', ())]
         kwargs['inputs'] = [Input.parse(i_data) for i_data in kwargs.pop('inputs', ())]
+        kwargs['mounts'] = [Mount.parse(m_data) for m_data in kwargs.pop('mounts', ())]
         return cls(**kwargs)
 
     def serialize(self):
@@ -42,6 +47,8 @@ class Step(object):
             val['parameters'] = list(p.serialize() for p in self.parameters.values())
         if self.inputs:
             val['inputs'] = list(i.serialize() for i in self.inputs.values())
+        if self.mounts:
+            val['mounts'] = [m.serialize() for m in self.mounts]
         if self.outputs:
             val['outputs'] = self.outputs
         return val

--- a/valohai_yaml/schema/mount-item.yaml
+++ b/valohai_yaml/schema/mount-item.yaml
@@ -1,0 +1,23 @@
+---
+anyOf:
+  - type: string
+    pattern: ^/.+:/.+$
+    description: A simple source:destination mount string. Note both parts must be absolute.
+  - type: object
+    required:
+    - source
+    - destination
+    additionalProperties: false
+    properties:
+      source:
+        type: string
+        pattern: ^/.+$
+        description: Host path for data
+      destination:
+        type: string
+        pattern: ^/.+$
+        description: Container path for data
+      readonly:
+        type: boolean
+        description: Whether to mount the volume read-only
+        default: false

--- a/valohai_yaml/schema/step.yaml
+++ b/valohai_yaml/schema/step.yaml
@@ -26,3 +26,7 @@ properties:
     type: array
     items:
       "$ref": "./param-item.json"
+  mounts:
+    type: array
+    items:
+      "$ref": "./mount-item.json"


### PR DESCRIPTION
Example step with two mount styles (string and object):

```yaml
- step:
    name: test
    image: busybox
    command: foo {parameters}
    mounts:
      - /foo:/bar
      - source: /baz
        destination: /quux
        readonly: true
```