### PR TITLE
Add support for {parameter:...} and {parameter-value:...} interpolations

### DIFF
--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -34,3 +34,28 @@ def test_command_override(example1_config):
 def test_nonexistent_interpolation_keys():
     interp_command = build_command(['Where are the ${shell_unicorns}? The {parameters} are here!'], ['ponies'])
     assert interp_command == ['Where are the ${shell_unicorns}? The ponies are here!']
+
+
+def test_parameter_interpolation(example1_config):
+    config = example1_config
+    step = config.steps['run training']
+    command = step.build_command(
+        parameter_values={'decoder-spec': 'hello'},
+        command='asdf {parameter:decoder-spec} {parameter:hello} {parameter:decoder-spec}',
+    )
+    command = ' && '.join(command)
+    assert command == 'asdf --decoder-spec hello {parameter:hello} --decoder-spec hello'
+
+
+def test_parameter_value_interpolation(example1_config):
+    config = example1_config
+    step = config.steps['run training']
+    command = step.build_command(
+        parameter_values={'decoder-spec': 'hello'},
+        command=[
+            'asdf {parameter-value:decoder-spec} {parameter-value:hello} {parameter-value:decoder-spec}',
+            '{parameter-value:decoder-spec}',
+        ]
+    )
+    command = ' && '.join(command)
+    assert command == 'asdf hello {parameter-value:hello} hello && hello'

--- a/valohai_yaml/commands.py
+++ b/valohai_yaml/commands.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import re
 import warnings
 
+from valohai_yaml.objs.parameter_map import LegacyParameterMap
 from valohai_yaml.utils import listify
 
 try:
@@ -15,9 +16,34 @@ class CommandInterpolationWarning(UserWarning):
     pass
 
 
-def build_command(command, parameters):
+interpolable_re = re.compile(r'{(.+?)}')
+
+
+def quote_multiple(args):
+    if not args:
+        return ''
+    return ' '.join(quote(arg) for arg in args)
+
+
+def _replace_interpolation(parameter_map, match):
+    value = match.group(1)
+    if value in ('parameters', 'params'):
+        return quote_multiple(parameter_map.build_parameters())
+    elif value.startswith('parameter:'):
+        parameter_name = value.split(':', 1)[1]
+        if parameter_name in parameter_map.parameters:
+            return quote_multiple(parameter_map.build_parameter_by_name(parameter_name))
+    elif value.startswith('parameter-value:'):
+        parameter_name = value.split(':', 1)[1]
+        value = parameter_map.values.get(parameter_name)
+        if value:
+            return quote(value)
+    return match.group(0)  # Return the original otherwise
+
+
+def build_command(command, parameter_map):
     """
-    Build command line(s) using the given parameter values.
+    Build command line(s) using the given parameter map.
 
     Even if the passed a single `command`, this function will return a list
     of shell commands.  It is the caller's responsibility to concatenate them,
@@ -25,16 +51,16 @@ def build_command(command, parameters):
 
     :param command: The command to interpolate params into.
     :type command: str|list[str]
-    :param parameter_values: Command line parameters for the {parameters} placeholder.
-                             These are quoted within `build_command`.
-    :type parameter_values: list[str]
+    :param parameter_map: A ParameterMap object containing parameter knowledge.
+    :type parameter_map: valohai_yaml.objs.parameter_map.ParameterMap
 
     :return: list of commands
     :rtype: list[str]
     """
-    parameters_str = ' '.join(quote(parameter) for parameter in parameters)
-    # format each command
-    env = dict(parameters=parameters_str, params=parameters_str)
+
+    if isinstance(parameter_map, list):  # Partially emulate old (pre-0.6) API for this function.
+        parameter_map = LegacyParameterMap(parameter_map)
+
     out_commands = []
     for command in listify(command):
         # Only attempt formatting if the string smells like it should be formatted.
@@ -42,16 +68,15 @@ def build_command(command, parameters):
         # (There's still naturally the chance for false-positives, so guard against
         #  those value errors and warn about them.)
 
-        if any('{%s}' % key in command for key in env):
+        if interpolable_re.search(command):
             try:
-                command = re.sub(
-                    r'{(.+?)}',
-                    lambda match: env.get(match.group(1), '{%s}' % match.group(1)),
+                command = interpolable_re.sub(
+                    lambda match: _replace_interpolation(parameter_map, match),
                     command,
                 )
             except ValueError as exc:  # pragma: no cover
                 warnings.warn(
-                    'failed to interpolate parameters into %r: %s' % (command, exc),
+                    'failed to interpolate into %r: %s' % (command, exc),
                     CommandInterpolationWarning
                 )
         out_commands.append(command.strip())

--- a/valohai_yaml/objs/parameter.py
+++ b/valohai_yaml/objs/parameter.py
@@ -82,3 +82,16 @@ class Parameter(_SimpleObject):
         if self.type == 'flag':
             return '--{name}'
         return '--{name}={value}'
+
+    def format_cli(self, value):
+        """
+        Build a single parameter argument.
+
+        :return: list of CLI strings -- not escaped. If the parameter should not be expressed, returns None.
+        :rtype: list[str]|None
+        """
+        if value is None or (self.type == 'flag' and not value):
+            return None
+        pass_as_bits = six.text_type(self.pass_as or self.default_pass_as).split()
+        env = dict(name=self.name, value=value, v=value)
+        return [bit.format(**env) for bit in pass_as_bits]

--- a/valohai_yaml/objs/parameter_map.py
+++ b/valohai_yaml/objs/parameter_map.py
@@ -1,0 +1,34 @@
+class ParameterMap:
+    def __init__(self, parameters, values):
+        self.parameters = parameters
+        self.values = values
+
+    def build_parameters(self):
+        """
+        Build the CLI command line from the parameter values.
+
+        :return: list of CLI strings -- not escaped!
+        :rtype: list[str]
+        """
+        param_bits = []
+        for name in self.parameters:
+            param_bits.extend(self.build_parameter_by_name(name) or [])
+        return param_bits
+
+    def build_parameter_by_name(self, name):
+        param = self.parameters[name]
+        value = self.values.get(param.name)
+        return param.format_cli(value)
+
+
+class LegacyParameterMap:
+    def __init__(self, parameters_list):
+        self.parameters_list = parameters_list
+        self.parameters = {}
+        self.values = {}
+
+    def build_parameters(self):
+        return self.parameters_list[:]
+
+    def build_parameter_by_name(self, name):  # pragma: no cover
+        return None

--- a/valohai_yaml/objs/step.py
+++ b/valohai_yaml/objs/step.py
@@ -2,9 +2,8 @@ from __future__ import unicode_literals
 
 from collections import OrderedDict
 
-import six
-
 from valohai_yaml.commands import build_command
+from valohai_yaml.objs.parameter_map import ParameterMap
 
 from .input import Input
 from .mount import Mount
@@ -65,24 +64,9 @@ class Step(object):
             if parameter.default is not None
         }
 
-    def build_parameters(self, param_values):
-        """
-        Build the CLI command line from the given parameter values.
-
-        :param param_values: mapping from parameter name to value
-        :type param_values: dict[str, object]
-        :return: list of CLI strings -- not escaped!
-        :rtype: list[str]
-        """
-        param_bits = []
-        for name, param in self.parameters.items():
-            value = param_values.get(name)
-            if value is None or (param.type == 'flag' and not value):
-                continue
-            pass_as_bits = six.text_type(param.pass_as or param.default_pass_as).split()
-            env = dict(name=name, value=value, v=value)
-            param_bits.extend(bit.format(**env) for bit in pass_as_bits)
-        return param_bits
+    def build_parameters(self, param_values):  # pragma: no cover
+        # TODO: Legacy; no longer used internally. Remove at 1.0.
+        return ParameterMap(self.parameters, param_values).build_parameters()
 
     def build_command(self, parameter_values, command=None):
         """
@@ -105,5 +89,5 @@ class Step(object):
         command = (command or self.command)
         # merge defaults with passed values
         values = dict(self.get_parameter_defaults(), **parameter_values)
-        parameters = self.build_parameters(values)
-        return build_command(command, parameters)
+        parameter_map = ParameterMap(parameters=self.parameters, values=values)
+        return build_command(command, parameter_map)


### PR DESCRIPTION
Unfortunately this changes the API of `valohai_yaml.commands.build_command` somewhat, but the new code has emulation for the old API.