### PR TITLE
Stringify values before quoting for `parameter-value`

### DIFF
--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -36,11 +36,17 @@ def test_nonexistent_interpolation_keys():
     assert interp_command == ['Where are the ${shell_unicorns}? The ponies are here!']
 
 
+parameter_test_values = {
+    'decoder-spec': 'hello',
+    'num-epochs': 840,
+}
+
+
 def test_parameter_interpolation(example1_config):
     config = example1_config
     step = config.steps['run training']
     command = step.build_command(
-        parameter_values={'decoder-spec': 'hello'},
+        parameter_values=parameter_test_values,
         command='asdf {parameter:decoder-spec} {parameter:hello} {parameter:decoder-spec}',
     )
     command = ' && '.join(command)
@@ -51,11 +57,12 @@ def test_parameter_value_interpolation(example1_config):
     config = example1_config
     step = config.steps['run training']
     command = step.build_command(
-        parameter_values={'decoder-spec': 'hello'},
+        parameter_values=parameter_test_values,
         command=[
             'asdf {parameter-value:decoder-spec} {parameter-value:hello} {parameter-value:decoder-spec}',
+            'dsfargeg {parameter-value:num-epochs}',
             '{parameter-value:decoder-spec}',
-        ]
+        ],
     )
     command = ' && '.join(command)
-    assert command == 'asdf hello {parameter-value:hello} hello && hello'
+    assert command == 'asdf hello {parameter-value:hello} hello && dsfargeg 840 && hello'

--- a/valohai_yaml/commands.py
+++ b/valohai_yaml/commands.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import re
 import warnings
 
+from valohai_yaml._compat import text_type
 from valohai_yaml.objs.parameter_map import LegacyParameterMap
 from valohai_yaml.utils import listify
 
@@ -37,7 +38,7 @@ def _replace_interpolation(parameter_map, match):
         parameter_name = value.split(':', 1)[1]
         value = parameter_map.values.get(parameter_name)
         if value:
-            return quote(value)
+            return quote(text_type(value))
     return match.group(0)  # Return the original otherwise
 
 


### PR DESCRIPTION
Fixes a bug encountered by Marshall.