### PR TITLE
Bad shorthand edge validation

### DIFF
--- a/tests/error_examples/invalid-shorthand-edge.yaml
+++ b/tests/error_examples/invalid-shorthand-edge.yaml
@@ -1,0 +1,16 @@
+- step:
+    name: Execution
+    image: busybox
+    command:
+      - date
+    inputs:
+      - name: training-images
+      - name: training-labels
+- pipeline:
+    name: Mipeline
+    nodes:
+      - name: batch1
+        type: execution
+        step: Execution
+    edges:
+      - [ batch1.input.training-labels* ]

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -1,7 +1,7 @@
 import pytest
 
 from valohai_yaml.objs import Parameter
-from valohai_yaml.validation import ValidationErrors
+from valohai_yaml import ValidationErrors
 
 
 @pytest.mark.parametrize('case', (-5, 15))

--- a/valohai_yaml/__init__.py
+++ b/valohai_yaml/__init__.py
@@ -1,4 +1,5 @@
 from .parsing import parse  # noqa
-from .validation import validate, ValidationErrors  # noqa
+from .validation import validate  # noqa
+from .excs import ValidationErrors  # noqa
 
 __version__ = '0.14.1'

--- a/valohai_yaml/excs.py
+++ b/valohai_yaml/excs.py
@@ -1,0 +1,22 @@
+from typing import List, Union
+
+import jsonschema
+
+
+class ValidationError(ValueError):
+    pass
+
+
+class ValidationErrors(ValidationError):
+
+    def __init__(self, errors: List[Union[str, jsonschema.ValidationError]]) -> None:
+        self.errors = errors
+        super(ValidationErrors, self).__init__(
+            '%d errors: %s' % (
+                len(errors),
+                ', '.join(getattr(e, 'message', e) for e in self.errors)
+            )
+        )
+
+    def __iter__(self):
+        return iter(self.errors)

--- a/valohai_yaml/lint.py
+++ b/valohai_yaml/lint.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from typing import Iterator, Optional
 
 from jsonschema.exceptions import relevance
 
@@ -12,10 +12,10 @@ class LintResult:
     def __init__(self) -> None:
         self.messages = []
 
-    def add_error(self, message: str, location: None = None, exception: None = None) -> None:
+    def add_error(self, message: str, location: None = None, exception: Optional[Exception] = None) -> None:
         self.messages.append({'type': 'error', 'message': message, 'location': location, 'exception': exception})
 
-    def add_warning(self, message: str, location: None = None, exception: None = None) -> None:
+    def add_warning(self, message: str, location: None = None, exception: Optional[Exception] = None) -> None:
         self.messages.append({'type': 'warning', 'message': message, 'location': location, 'exception': exception})
 
     @property

--- a/valohai_yaml/lint.py
+++ b/valohai_yaml/lint.py
@@ -2,6 +2,7 @@ from typing import Iterator, Optional
 
 from jsonschema.exceptions import relevance
 
+from valohai_yaml.excs import ValidationError
 from valohai_yaml.objs import Config
 from valohai_yaml.utils import read_yaml
 from valohai_yaml.utils.terminal import style
@@ -83,6 +84,10 @@ def lint(yaml) -> LintResult:
     if len(errors) > 0:
         return lr
 
-    config = Config.parse(data)
-    config.lint(lr, context={})
+    try:
+        config = Config.parse(data)
+    except ValidationError as err:  # Could happen before we get to linting things
+        lr.add_error(str(err), exception=err)
+    else:
+        config.lint(lr, context={})
     return lr

--- a/valohai_yaml/objs/parameter.py
+++ b/valohai_yaml/objs/parameter.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Optional, Union
 
 from valohai_yaml.utils import listify
-from valohai_yaml.validation import ValidationErrors
+from valohai_yaml.excs import ValidationErrors
 from .base import Item
 
 

--- a/valohai_yaml/objs/pipelines/edge.py
+++ b/valohai_yaml/objs/pipelines/edge.py
@@ -12,7 +12,7 @@ edge_types = {'input', 'output', 'parameter', 'metadata', 'file'}
 
 
 class Edge(Item):
-    def __init__(self, *, source, target, configuration=None) -> None:
+    def __init__(self, *, source: str, target: str, configuration=None) -> None:
         if configuration is None:
             configuration = {}
         self.source = source
@@ -20,28 +20,20 @@ class Edge(Item):
         self.configuration = configuration
 
     @property
-    def source_node(self) -> str:
-        return _split_prop(self.source)[0]
+    def source(self) -> str:
+        return '.'.join((self.source_node, self.source_type, self.source_key))
+
+    @source.setter
+    def source(self, prop: str) -> None:
+        self.source_node, self.source_type, self.source_key = _split_prop(prop)
 
     @property
-    def source_type(self) -> str:
-        return _split_prop(self.source)[1]
+    def target(self) -> str:
+        return '.'.join((self.target_node, self.target_type, self.target_key))
 
-    @property
-    def source_key(self) -> str:
-        return _split_prop(self.source)[2]
-
-    @property
-    def target_node(self) -> str:
-        return _split_prop(self.target)[0]
-
-    @property
-    def target_type(self) -> str:
-        return _split_prop(self.target)[1]
-
-    @property
-    def target_key(self) -> str:
-        return _split_prop(self.target)[2]
+    @target.setter
+    def target(self, prop: str) -> None:
+        self.target_node, self.target_type, self.target_key = _split_prop(prop)
 
     @classmethod
     def parse(cls, data: Union[dict, list]) -> 'Edge':
@@ -50,6 +42,13 @@ class Edge(Item):
                 raise ValidationError('Malformed edge shorthand {}'.format(data))
             data = {'source': data[0], 'target': data[1]}
         return super(Edge, cls).parse(data)
+
+    def get_data(self) -> dict:
+        return {
+            'source': self.source,
+            'target': self.target,
+            'configuration': self.configuration,
+        }
 
     def lint(self, lint_result, context) -> None:
         pipeline = context['pipeline']

--- a/valohai_yaml/objs/pipelines/edge.py
+++ b/valohai_yaml/objs/pipelines/edge.py
@@ -1,6 +1,7 @@
 from typing import List, Union
 
 from ..base import Item
+from valohai_yaml.excs import ValidationError
 
 
 def _split_prop(prop: str) -> List[str]:
@@ -45,6 +46,8 @@ class Edge(Item):
     @classmethod
     def parse(cls, data: Union[dict, list]) -> 'Edge':
         if isinstance(data, list):  # Must be a shorthand
+            if len(data) != 2:
+                raise ValidationError('Malformed edge shorthand {}'.format(data))
             data = {'source': data[0], 'target': data[1]}
         return super(Edge, cls).parse(data)
 

--- a/valohai_yaml/validation.py
+++ b/valohai_yaml/validation.py
@@ -1,30 +1,16 @@
 import json
 import os
 import re
-from typing import List, Union
+from typing import List
 
 import yaml
 from jsonschema import Draft4Validator, RefResolver, ValidationError
 from jsonschema.compat import lru_cache
 
+from .excs import ValidationErrors
 from .utils import read_yaml
 
 SCHEMATA_DIRECTORY = os.path.join(os.path.dirname(__file__), 'schema')
-
-
-class ValidationErrors(ValueError):
-
-    def __init__(self, errors: List[Union[str, ValidationError]]) -> None:
-        self.errors = errors
-        super(ValidationErrors, self).__init__(
-            '%d errors: %s' % (
-                len(errors),
-                ', '.join(getattr(e, 'message', e) for e in self.errors)
-            )
-        )
-
-    def __iter__(self):
-        return iter(self.errors)
 
 
 class LocalRefResolver(RefResolver):


### PR DESCRIPTION
This PR:

* enhances the exception hierarchy for validation errors
* adds validation for invalid edge shorthands like `- ['preprocess.output.*.npz']` (fixes #41)
* changes up the parsing for edge type/node/key to be eager