### PR TITLE
Drop LegacyParameterMap (a relic from 2018)

### DIFF
--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,4 +1,5 @@
 from valohai_yaml.commands import build_command
+from valohai_yaml.objs.parameter_map import ParameterMap
 
 
 def test_command_generation(example1_config):
@@ -32,8 +33,9 @@ def test_command_override(example1_config):
 
 
 def test_nonexistent_interpolation_keys():
-    interp_command = build_command(['Where are the ${shell_unicorns}? The {parameters} are here!'], ['ponies'])
-    assert interp_command == ['Where are the ${shell_unicorns}? The ponies are here!']
+    empty_parameter_map = ParameterMap(parameters={}, values={})
+    interp_command = build_command(['Where are the ${shell_unicorns}? The {parameters} are here!'], empty_parameter_map)
+    assert interp_command == ['Where are the ${shell_unicorns}? The  are here!']
 
 
 parameter_test_values = {

--- a/valohai_yaml/commands.py
+++ b/valohai_yaml/commands.py
@@ -3,7 +3,7 @@ import warnings
 from shlex import quote
 from typing import List, TYPE_CHECKING, Union
 
-from valohai_yaml.objs.parameter_map import LegacyParameterMap, ParameterMap
+from valohai_yaml.objs.parameter_map import ParameterMap
 from valohai_yaml.utils import listify
 
 if TYPE_CHECKING:
@@ -23,7 +23,7 @@ def quote_multiple(args: List[str]) -> str:
     return ' '.join(quote(arg) for arg in args)
 
 
-def _replace_interpolation(parameter_map: Union[ParameterMap, LegacyParameterMap], match: 'Match') -> str:
+def _replace_interpolation(parameter_map: ParameterMap, match: 'Match') -> str:
     value = match.group(1)
     if value in ('parameters', 'params'):
         return quote_multiple(parameter_map.build_parameters())
@@ -41,7 +41,7 @@ def _replace_interpolation(parameter_map: Union[ParameterMap, LegacyParameterMap
 
 def build_command(
     command: Union[str, List[str]],
-    parameter_map: Union[ParameterMap, LegacyParameterMap, list],
+    parameter_map: ParameterMap,
 ) -> List[str]:
     """
     Build command line(s) using the given parameter map.
@@ -59,8 +59,8 @@ def build_command(
     :rtype: list[str]
     """
 
-    if isinstance(parameter_map, list):  # Partially emulate old (pre-0.7) API for this function.
-        parameter_map = LegacyParameterMap(parameter_map)
+    if isinstance(parameter_map, list):
+        raise TypeError("Passing in lists as ParameterMaps is no longer supported.")
 
     out_commands = []
     for command in listify(command):

--- a/valohai_yaml/objs/parameter_map.py
+++ b/valohai_yaml/objs/parameter_map.py
@@ -24,16 +24,3 @@ class ParameterMap:
         param = self.parameters[name]
         value = self.values.get(param.name)
         return param.format_cli(value)
-
-
-class LegacyParameterMap:
-    def __init__(self, parameters_list: List[str]) -> None:
-        self.parameters_list = parameters_list
-        self.parameters = {}
-        self.values = {}
-
-    def build_parameters(self) -> List[str]:
-        return self.parameters_list[:]
-
-    def build_parameter_by_name(self, name):  # pragma: no cover
-        return None


### PR DESCRIPTION
It's pretty safe to assume no one uses the legacy API anymore.