### PR TITLE
Import lru_cache from functools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/checkout@v2
       - run: pip install -U pip setuptools wheel
       - run: 'pip install -e . -r requirements-test.txt'
+      - run: 'pip install -U jsonschema==3.2.0'
+        if: '${{ matrix.python-version }} == ''3.5'''
       - run: py.test -vvv --cov .
       - run: 'bash <(curl -s https://codecov.io/bash)'
   Lint:

--- a/valohai_yaml/validation.py
+++ b/valohai_yaml/validation.py
@@ -1,11 +1,11 @@
 import json
 import os
 import re
+from functools import lru_cache
 from typing import IO, List, Union
 
 import yaml
 from jsonschema import Draft4Validator, RefResolver, ValidationError
-from jsonschema.compat import lru_cache
 
 from .excs import ValidationErrors
 from .utils import read_yaml


### PR DESCRIPTION
Fixes compatibility with jsonschema>=4.0.

There's no good reason to have been importing the decorator from jsonschema anyway, since it's been in the stdlib since 3.3.