### PR TITLE
Add optional `resources` to endpoint definition

### DIFF
--- a/examples/endpoint-example.yaml
+++ b/examples/endpoint-example.yaml
@@ -15,3 +15,16 @@
       - name: model
         description: Model output file from TensorFlow
         path: model.pb
+
+- endpoint:
+    name: limited-endpoint
+    image: python:3.9
+    server-command:
+      - python run_server.py
+    resources:
+      cpu:
+        min: 0.1
+        max: 1
+      memory:
+        min: 50
+        max: 100

--- a/tests/test_endpoint_parsing.py
+++ b/tests/test_endpoint_parsing.py
@@ -1,14 +1,25 @@
-def test_endpoint_parse(endpoint_config):
-    server_endpoint = endpoint_config.endpoints['server-endpoint']
-    assert server_endpoint.image == 'python:3.6'
-    assert server_endpoint.port == 1453
-    assert server_endpoint.server_command == 'python run_server.py'
-    wsgi_endpoint = endpoint_config.endpoints['wsgi-endpoint']
-    assert wsgi_endpoint.description == 'predict digits from image inputs'
-    assert wsgi_endpoint.image == 'tensorflow/tensorflow:1.3.0-py3'
-    assert wsgi_endpoint.wsgi == 'predict_wsgi:predict_wsgi'
-    assert len(wsgi_endpoint.files) == 1
-    file = wsgi_endpoint.files[0]
+def test_server_endpoint_parse(endpoint_config):
+    endpoint = endpoint_config.endpoints['server-endpoint']
+    assert endpoint.image == 'python:3.6'
+    assert endpoint.port == 1453
+    assert endpoint.server_command == 'python run_server.py'
+
+
+def test_wsgi_endpoint_parse(endpoint_config):
+    endpoint = endpoint_config.endpoints['wsgi-endpoint']
+    assert endpoint.description == 'predict digits from image inputs'
+    assert endpoint.image == 'tensorflow/tensorflow:1.3.0-py3'
+    assert endpoint.wsgi == 'predict_wsgi:predict_wsgi'
+    assert len(endpoint.files) == 1
+    file = endpoint.files[0]
     assert file.name == 'model'
     assert file.description == 'Model output file from TensorFlow'
     assert file.path == 'model.pb'
+
+
+def test_limited_endpoint_parse(endpoint_config):
+    endpoint = endpoint_config.endpoints['limited-endpoint']
+    assert endpoint.resources['cpu']['min'] == 0.1
+    assert endpoint.resources['cpu']['max'] == 1.0
+    assert endpoint.resources['memory']['min'] == 50
+    assert endpoint.resources['memory']['max'] == 100

--- a/valohai_yaml/objs/endpoint.py
+++ b/valohai_yaml/objs/endpoint.py
@@ -17,7 +17,8 @@ class Endpoint(Item):
         files: Iterable[File] = (),
         port: Optional[Union[str, int]] = None,
         server_command: Optional[str] = None,
-        wsgi: Optional[str] = None
+        wsgi: Optional[str] = None,
+        resources: Optional[Dict] = None
     ) -> None:
         self.name = name
         self.description = description
@@ -26,6 +27,7 @@ class Endpoint(Item):
         self.server_command = server_command
         self.wsgi = wsgi
         self.files = check_type_and_listify(files, File)
+        self.resources = resources
 
     @classmethod
     def parse(cls, kwargs: Dict[str, Any]) -> 'Endpoint':

--- a/valohai_yaml/schema/endpoint.yaml
+++ b/valohai_yaml/schema/endpoint.yaml
@@ -41,6 +41,29 @@ properties:
       Specifies the WSGI application to serve (e.g. a Flask application).
       Specify the module (i.e. `package.app`) or
       the module and the WSGI callable (i.e. `package.app:wsgi_callable`).
+  resources:
+    type: object
+    description: Resource requirements and limits for the endpoint.
+    additionalProperties: false
+    properties:
+      cpu:
+        type: object
+        description: CPU resource requirements and limits in vCPU counts e.g. 0.1 is 10% of one CPU.
+        additionalProperties: false
+        properties:
+          min:
+            type: number
+          max:
+            type: number
+      memory:
+        type: object
+        description: Memory requirements and limits in MB e.g. 100 is 100 MB.
+        additionalProperties: false
+        properties:
+          min:
+            type: number
+          max:
+            type: number
 oneOf:
   - required:
       - server-command


### PR DESCRIPTION
Dropping some groundwork for defining default resource values for Valohai endpoints.

Only consideration was that should we use more generic terms (`min/max`) or Kubernetes terms (`requests/limits`) but I opted for generic terms for data scientists as they shouldn't really be concerned with inner workings of Kubernetes.

In a perfect world, we would use vertical pod autoscaling but that is not an option for all installations, and this definition can extended to configure that scaling.

This can also be extended with other hardware requirements like GPUs and the like.