### PR TITLE
Correct return type for merge_with

### DIFF
--- a/valohai_yaml/objs/base.py
+++ b/valohai_yaml/objs/base.py
@@ -52,7 +52,7 @@ class Item:
     def lint(self, lint_result: LintResult, context: dict) -> None:
         pass
 
-    def merge_with(self: T, other: T, strategy: Optional[Callable[[T, T], T]] = None) -> 'Item':
+    def merge_with(self: T, other: T, strategy: Optional[Callable[[T, T], T]] = None) -> T:
         if strategy is None:
             strategy = self.default_merge
         return strategy(self, other)


### PR DESCRIPTION
The return type for merge_with was erroneously left `Item` though we know the merge will always return exactly `T` (whose bound is Item).