### PR TITLE
Do not keep empty Node `actions` in serialized output

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -72,3 +72,11 @@ def test_action_pipeline(pipeline_config: Config):
         'then': ['noop'],
         'when': ['node-complete', 'node-starting'],
     }
+
+
+def test_empty_actions_not_serialized(pipeline_config: Config):
+    pl = pipeline_config.pipelines["Last action pipeline"]
+    train_node = pl.get_node_by(name='train')
+    assert train_node
+    train_node.actions.clear()
+    assert 'actions' not in train_node.serialize()

--- a/valohai_yaml/objs/pipelines/node.py
+++ b/valohai_yaml/objs/pipelines/node.py
@@ -43,6 +43,8 @@ class Node(Item):
     def serialize(self) -> dict:
         ser = super().serialize()
         ser['type'] = self.type
+        if not ser.get('actions'):
+            ser.pop('actions', None)
         return ser
 
     def lint(self, lint_result: LintResult, context: dict) -> None:


### PR DESCRIPTION
There's no need to have the optional empty list there if the input maybe wasn't there in the first place.

This is currently breaking a test in https://github.com/valohai/valohai-utils/pull/75 since valohai-yaml got bumped to 0.20.0 there.