### PR TITLE
Pipeline conversion API

### DIFF
--- a/tests/test_pipeline_conversion.py
+++ b/tests/test_pipeline_conversion.py
@@ -1,0 +1,12 @@
+from valohai_yaml.objs import Config
+from valohai_yaml.pipelines.conversion import PipelineConverter
+
+
+def test_pipeline_conversion_smoke(pipeline_config: Config):
+    for _name, pipeline in pipeline_config.pipelines.items():
+        result = PipelineConverter(
+            config=pipeline_config,
+            commit_identifier="latest",
+        ).convert_pipeline(pipeline)
+        assert result["nodes"]
+        assert result["edges"]

--- a/valohai_yaml/objs/pipelines/edge.py
+++ b/valohai_yaml/objs/pipelines/edge.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
 from valohai_yaml.excs import ValidationError
 from valohai_yaml.lint import LintResult
@@ -69,6 +69,20 @@ class Edge(Item):
             'target': self.target,
             'configuration': self.configuration,
         }
+
+    def get_expanded(self) -> Dict[str, Any]:
+        """Get the "expanded" form of this edge."""
+        result: Dict[str, Any] = {
+            'source_node': self.source_node,
+            'source_type': self.source_type,
+            'source_key': self.source_key,
+            'target_node': self.target_node,
+            'target_type': self.target_type,
+            'target_key': self.target_key,
+        }
+        if self.configuration:
+            result['configuration'] = self.configuration
+        return result
 
     def lint(self, lint_result: LintResult, context: LintContext) -> None:
         pipeline = context['pipeline']  # type: Pipeline

--- a/valohai_yaml/objs/pipelines/node.py
+++ b/valohai_yaml/objs/pipelines/node.py
@@ -27,7 +27,7 @@ class Node(Item):
         actions: Optional[List[NodeAction]] = None
     ) -> None:
         self.name = name
-        self.actions = check_type_and_listify(actions, NodeAction)
+        self.actions = check_type_and_listify(actions, NodeAction, parse=NodeAction.parse)
 
     @classmethod
     def parse_qualifying(cls, data: SerializedDict) -> 'Node':

--- a/valohai_yaml/pipelines/conversion.py
+++ b/valohai_yaml/pipelines/conversion.py
@@ -1,0 +1,67 @@
+from typing import Any, Dict, List, Union
+
+from valohai_yaml.objs import Config, DeploymentNode, ExecutionNode, Node, Pipeline, TaskNode
+from valohai_yaml.utils import listify
+
+ConvertedObject = Dict[str, Any]
+
+
+class PipelineConverter:
+    """Converts pipeline objects to Valohai API payloads."""
+
+    def __init__(
+        self,
+        *,
+        config: Config,
+        commit_identifier: str,
+    ) -> None:
+        self.config = config
+        self.commit_identifier = commit_identifier
+
+    def convert_pipeline(self, pipeline: Pipeline) -> Dict[str, List[ConvertedObject]]:
+        return {
+            "edges": [edge.get_expanded() for edge in pipeline.edges],
+            "nodes": [self.convert_node(node) for node in pipeline.nodes],
+        }
+
+    def convert_node(self, node: Node) -> ConvertedObject:
+        if isinstance(node, (ExecutionNode, TaskNode)):
+            return self.convert_executionlike_node(node)
+        if isinstance(node, DeploymentNode):
+            return self.convert_deployment_node(node)
+        return node.serialize()  # Assume default serialization works
+
+    def convert_deployment_node(self, node: DeploymentNode) -> ConvertedObject:
+        node_data = node.serialize()
+        node_data["commit"] = self.commit_identifier
+        node_data["endpoint_configurations"] = {
+            f"{name}": {
+                "files": {},
+                "enabled": True,
+            }
+            for name, endpoint in self.config.endpoints.items()
+            if name in node.endpoints
+        }
+        node_data["aliases"] = node.aliases
+        return node_data
+
+    def convert_executionlike_node(self, node: Union[ExecutionNode, TaskNode]) -> ConvertedObject:
+        node_data = node.serialize()
+        step_name = node_data.pop("step")
+        override = node_data.pop("override")
+        step = self.config.get_step_by(name=step_name)
+        if not step:  # pragma: no cover
+            raise ValueError(f"Step {step_name} not found in {self.config}")
+        step_data = step.serialize()
+        step_data["parameters"] = step.get_parameter_defaults(include_flags=True)
+        step_data["inputs"] = {
+            i["name"]: listify(i.get("default")) for i in step_data.get("inputs", [])
+        }
+        step_data.pop("mounts", None)
+        node_data["template"] = {
+            "commit": self.commit_identifier,
+            "step": step_name,
+            **step_data,
+            **override,
+        }
+        return node_data


### PR DESCRIPTION
This makes it easier for downstream users to convert YAML style pipeline definitions to payload style (though YAML style pipelines will be allowed as payloads in the near future anyway).