### PR TITLE
Correct order of applying overrides to step data when converting nodes

### DIFF
--- a/examples/pipeline-example.yaml
+++ b/examples/pipeline-example.yaml
@@ -81,6 +81,9 @@
       - name: train
         type: execution
         step: Train model
+        override:
+          inputs:
+            - name: training-images
       - name: test
         type: execution
         step: Test model

--- a/tests/test_pipeline_conversion.py
+++ b/tests/test_pipeline_conversion.py
@@ -10,3 +10,13 @@ def test_pipeline_conversion_smoke(pipeline_config: Config):
         ).convert_pipeline(pipeline)
         assert result["nodes"]
         assert result["edges"]
+
+
+def test_pipeline_conversion_override_order(pipeline_config: Config):
+    result = PipelineConverter(
+        config=pipeline_config,
+        commit_identifier="latest",
+    ).convert_pipeline(pipeline_config.pipelines["My medium pipeline"])
+    train_node = next(node for node in result["nodes"] if node["name"] == "train")
+    # If conversion order is incorrect, this will have remained a list
+    assert isinstance(train_node["template"]["inputs"], dict)

--- a/valohai_yaml/pipelines/conversion.py
+++ b/valohai_yaml/pipelines/conversion.py
@@ -48,11 +48,12 @@ class PipelineConverter:
     def convert_executionlike_node(self, node: Union[ExecutionNode, TaskNode]) -> ConvertedObject:
         node_data = node.serialize()
         step_name = node_data.pop("step")
-        override = node_data.pop("override")
+        override = node_data.pop("override", {})
         step = self.config.get_step_by(name=step_name)
         if not step:  # pragma: no cover
             raise ValueError(f"Step {step_name} not found in {self.config}")
         step_data = step.serialize()
+        step_data.update(override)  # TODO: this might need to e.g. merge mappings
         step_data["parameters"] = step.get_parameter_defaults(include_flags=True)
         step_data["inputs"] = {
             i["name"]: listify(i.get("default")) for i in step_data.get("inputs", [])
@@ -62,6 +63,5 @@ class PipelineConverter:
             "commit": self.commit_identifier,
             "step": step_name,
             **step_data,
-            **override,
         }
         return node_data


### PR DESCRIPTION
The overrides need to be applied to the data before it is converted, not afterwards.
