### PR TITLE
Sort pipeline nodes and edges when serializing

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -80,3 +80,8 @@ def test_empty_actions_not_serialized(pipeline_config: Config):
     assert train_node
     train_node.actions.clear()
     assert 'actions' not in train_node.serialize()
+
+
+def test_node_sort_order(pipeline_config: Config):
+    node_names = [n["name"] for n in pipeline_config.pipelines["My deployment pipeline"].serialize()["nodes"]]
+    assert node_names == sorted(node_names)

--- a/valohai_yaml/objs/pipelines/pipeline.py
+++ b/valohai_yaml/objs/pipelines/pipeline.py
@@ -35,6 +35,13 @@ class Pipeline(Item):
         data['nodes'] = [Node.parse_qualifying(n) for n in data.pop('nodes', ())]
         return super().parse(data)
 
+    def serialize(self, sorted=True) -> Any:
+        data = super().serialize()
+        if sorted:
+            data['edges'].sort(key=lambda d: (d['source'], d['target']))
+            data['nodes'].sort(key=lambda d: d['name'])
+        return data
+
     def lint(self, lint_result: LintResult, context: LintContext) -> None:
         context = dict(context, pipeline=self)
         lint_iterables(lint_result, context, (self.nodes, self.edges))


### PR DESCRIPTION
This makes comparing serialized content much easier.