### PR TITLE
Readme: update development requirements installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ print(config.steps['cool step'].command)
 # Development
 
 ```bash
-pip install -e . -r requirements-test.txt -r requirements-lint.txt
+pip install -e .
+pip install -r requirements-lint.txt
+pip install -r requirements-test.txt
 pytest
 ```


### PR DESCRIPTION
[The readme](https://github.com/valohai/valohai-yaml/blob/2c75d96a406d308c9ae1f4d20526f606f9529ef1/README.md?plain=1#L56) says that development should be done with
`pip install -e . -r requirements-test.txt -r requirements-lint.txt`
however, it resolves into conflicting `toml` and `tomli` versions as `pytest-cov` from `requirements-lint` requests more recent version from both.

We could also make the development installation without `requirements-test.txt` as its content is all included in `requirements-lint`, but that seems confusing: _"why wouldn't I install test requirements when developing?"_

EDIT: the error message
```logs
ERROR: Cannot install coverage[toml]==6.2 and coverage[toml]==6.3.2 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested coverage[toml]==6.2
    The user requested coverage[toml]==6.3.2

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```