### PR TITLE
Don't require parameters when programmatically constructing pipelines

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-from valohai_yaml.objs import Config, DeploymentNode
+from valohai_yaml.objs import Config, DeploymentNode, Pipeline
 
 
 def test_pipeline_valid(pipeline_config: Config):
@@ -80,3 +80,7 @@ def test_empty_actions_not_serialized(pipeline_config: Config):
     assert train_node
     train_node.actions.clear()
     assert 'actions' not in train_node.serialize()
+
+
+def test_programmatic_pipeline_parameters():
+    assert Pipeline(name="...", nodes=[], edges=[]).parameters == []

--- a/valohai_yaml/objs/pipelines/pipeline.py
+++ b/valohai_yaml/objs/pipelines/pipeline.py
@@ -19,12 +19,12 @@ class Pipeline(Item):
         name: str,
         nodes: List[Node],
         edges: List[Edge],
-        parameters: List[PipelineParameter],
+        parameters: Optional[List[PipelineParameter]] = None,
     ) -> None:
         self.name = name
         self.nodes = nodes
         self.edges = edges
-        self.parameters = parameters
+        self.parameters = (parameters or [])
 
     @property
     def node_map(self) -> OrderedDict:  # type: ignore[type-arg]


### PR DESCRIPTION
Older code such as that in `papi` will not know about `parameters` and promptly crashes.