### PR TITLE
Add `node-selector` and `devices` to endpoint definitions

### DIFF
--- a/examples/endpoint-example.yaml
+++ b/examples/endpoint-example.yaml
@@ -28,3 +28,12 @@
       memory:
         min: 50
         max: 100
+
+- endpoint:
+    name: accelerated-endpoint
+    image: python:3.6
+    server-command: python run_server.py
+    node-selector: accelerator=tesla-v100
+    resources:
+      devices:
+        nvidia.com/gpu: 1

--- a/tests/test_endpoint_parsing.py
+++ b/tests/test_endpoint_parsing.py
@@ -23,3 +23,9 @@ def test_limited_endpoint_parse(endpoint_config):
     assert endpoint.resources['cpu']['max'] == 1.0
     assert endpoint.resources['memory']['min'] == 50
     assert endpoint.resources['memory']['max'] == 100
+
+
+def test_accelerated_endpoint_parse(endpoint_config):
+    endpoint = endpoint_config.endpoints['accelerated-endpoint']
+    assert endpoint.node_selector == 'accelerator=tesla-v100'
+    assert endpoint.resources['devices']['nvidia.com/gpu'] == 1

--- a/valohai_yaml/objs/endpoint.py
+++ b/valohai_yaml/objs/endpoint.py
@@ -19,6 +19,7 @@ class Endpoint(Item):
         port: Optional[Union[str, int]] = None,
         server_command: Optional[str] = None,
         wsgi: Optional[str] = None,
+        node_selector: Optional[str] = None,
         resources: Optional[EndpointResourcesDict] = None
     ) -> None:
         self.name = name
@@ -28,6 +29,7 @@ class Endpoint(Item):
         self.server_command = server_command
         self.wsgi = wsgi
         self.files = check_type_and_listify(files, File)
+        self.node_selector = node_selector
         self.resources = resources
 
     @classmethod

--- a/valohai_yaml/schema/endpoint.yaml
+++ b/valohai_yaml/schema/endpoint.yaml
@@ -41,6 +41,10 @@ properties:
       Specifies the WSGI application to serve (e.g. a Flask application).
       Specify the module (i.e. `package.app`) or
       the module and the WSGI callable (i.e. `package.app:wsgi_callable`).
+  node-selector:
+    type: string
+    description: Kubernetes node selector specifies which nodes the deployment should be scheduled to.
+    pattern: "="
   resources:
     type: object
     description: Resource requirements and limits for the endpoint.
@@ -64,6 +68,13 @@ properties:
             type: number
           max:
             type: number
+      devices:
+        type: object
+        description: "Devices required e.g. 'nvidia.com/gpu: 1' for one NVIDIA GPU."
+        patternProperties:
+          "^.+$":
+            type: number
+            minimum: 1
 oneOf:
   - required:
       - server-command


### PR DESCRIPTION
`resources.devices` can be used to specify which device plugin exposed devices the endpoint needs and how many

`node-selector` can be used to further specify device subtype if the nodes are properly labeled i.e. not just some GPU but a specific GPU

`node-selector` can be used alone to just select certain nodes to deploy on; likewise `resources.devices` can also be used to say that the endpoint needs "just some NVIDIA GPU"