### PR TITLE
Add step icon + category

### DIFF
--- a/examples/example1.yaml
+++ b/examples/example1.yaml
@@ -6,6 +6,8 @@
       Trains our core model. Remember to preprocess the dataset before training.
       Also, if hangs for more than 15 minutes without logs, kill the training,
       most likely has ran out of memory.
+    icon: https://valohai.com/assets/img/valohai-logo.svg
+    category: Training
     image: busybox
     command:
       - cd /tmp/code

--- a/tests/test_step_parsing.py
+++ b/tests/test_step_parsing.py
@@ -1,5 +1,6 @@
 import pytest
 
+from valohai_yaml.objs import Config
 from valohai_yaml.objs.input import Input, KeepDirectories
 
 
@@ -148,3 +149,8 @@ def test_timeouts(timeouts_config):
     assert timeouts_config.steps['big-no-output-timeout'].no_output_timeout.total_seconds() == 86400
     assert timeouts_config.steps['human-readable-time-limit'].time_limit.total_seconds() == 5405
     assert timeouts_config.steps['human-readable-time-limit'].no_output_timeout.total_seconds() == 86400 * 2  # 48h
+
+
+def test_bling(example1_config: Config) -> None:
+    assert example1_config.steps['run training'].category == "Training"
+    assert example1_config.steps['run training'].icon == "https://valohai.com/assets/img/valohai-logo.svg"

--- a/valohai_yaml/objs/step.py
+++ b/valohai_yaml/objs/step.py
@@ -41,12 +41,16 @@ class Step(Item):
         description: Optional[str] = None,
         time_limit: Optional[datetime.timedelta] = None,
         no_output_timeout: Optional[datetime.timedelta] = None,
+        icon: Optional[str] = None,
+        category: Optional[str] = None,
     ) -> None:
         self.name = name
         self.image = image
         self.command = command
         self.description = description
         self.environment = (str(environment) if environment else None)
+        self.icon = (str(icon) if icon else None)
+        self.category = (str(category) if category else None)
 
         self.outputs = list(outputs)  # TODO: Improve handling
         self.mounts = check_type_and_listify(mounts, Mount)
@@ -86,6 +90,8 @@ class Step(Item):
             ('description', self.description),
             ('time-limit', int(self.time_limit.total_seconds()) if self.time_limit else None),
             ('no-output-timeout', int(self.no_output_timeout.total_seconds()) if self.no_output_timeout else None),
+            ('icon', self.icon),
+            ('category', self.category),
         ]:
             serialize_into(val, key, source, flatten_dicts=True, elide_empty_iterables=True)
         return val

--- a/valohai_yaml/schema/step.yaml
+++ b/valohai_yaml/schema/step.yaml
@@ -65,3 +65,9 @@ properties:
       The time after which the step is considered to have died if no output has been generated
       (in seconds or as a string (e.g. "1h 30m 5s")).
       An unspecified value means "platform default".
+  icon:
+    type: string
+    description: URL to the icon representing the step
+  category:
+    type: string
+    description: Category name to group & organize steps in the UI


### PR DESCRIPTION
For the step library project, we want show logos and bling-bling, if the steps are things like 3rd party data platforms.
![Screenshot from 2023-01-23 17-20-00](https://user-images.githubusercontent.com/1525350/214078520-e31406be-874b-4866-8852-2466dff20d8a.png)

Example:
```
 - step:
     name: snowflake-query
     image: valohai/dbconnectors
     command: python query.py {parameters}
     icon: https://valohai.com/img/orig/SNOW-35164165.png
     category: Database query
```

Fixes https://github.com/valohai/valohai-yaml/issues/86