### PR TITLE
Execution Node: move runtime configs in runtime_config

### DIFF
--- a/examples/pipeline-example.yaml
+++ b/examples/pipeline-example.yaml
@@ -9,6 +9,8 @@
 - step:
     name: Train model
     image: busybox
+    # this sometimes gets stuck so we set a timeout
+    no-output-timeout: 6h
     command:
       - date
     inputs:

--- a/tests/test_pipeline_conversion.py
+++ b/tests/test_pipeline_conversion.py
@@ -1,5 +1,6 @@
 from valohai_yaml.objs import Config
 from valohai_yaml.pipelines.conversion import PipelineConverter
+from valohai_yaml.utils.duration import parse_duration_string
 
 
 def test_pipeline_conversion_smoke(pipeline_config: Config):
@@ -20,3 +21,12 @@ def test_pipeline_conversion_override_order(pipeline_config: Config):
     train_node = next(node for node in result["nodes"] if node["name"] == "train")
     # If conversion order is incorrect, this will have remained a list
     assert isinstance(train_node["template"]["inputs"], dict)
+
+
+def test_pipeline_conversion_no_output_timeout(pipeline_config: Config):
+    result = PipelineConverter(
+        config=pipeline_config,
+        commit_identifier="latest",
+    ).convert_pipeline(pipeline_config.pipelines["My medium pipeline"])
+    train_node = next(node for node in result["nodes"] if node["name"] == "train")
+    assert train_node["template"]["runtime_config"]["no_output_timeout"] == parse_duration_string("6h").total_seconds()

--- a/valohai_yaml/pipelines/conversion.py
+++ b/valohai_yaml/pipelines/conversion.py
@@ -62,6 +62,11 @@ class PipelineConverter:
         step_data = step.serialize()
         step_data.update(override)
 
+        runtime_config = step_data.get("runtime_config", {})
+        if 'no-output-timeout' in step_data:
+            runtime_config.setdefault('no_output_timeout', step_data.pop('no-output-timeout'))
+        step_data["runtime_config"] = runtime_config
+
         parameters_from_node = node.get_parameter_defaults()
         parameters_from_step = step.get_parameter_defaults(include_flags=True)
         step_data["parameters"] = parameters_from_step

--- a/valohai_yaml/pipelines/conversion.py
+++ b/valohai_yaml/pipelines/conversion.py
@@ -62,10 +62,9 @@ class PipelineConverter:
         step_data = step.serialize()
         step_data.update(override)
 
-        runtime_config = step_data.get("runtime_config", {})
-        if 'no-output-timeout' in step_data:
-            runtime_config.setdefault('no_output_timeout', step_data.pop('no-output-timeout'))
-        step_data["runtime_config"] = runtime_config
+        runtime_config = step_data.setdefault("runtime_config", {})
+        if "no-output-timeout" in step_data:
+            runtime_config.setdefault("no_output_timeout", step_data.pop("no-output-timeout"))
 
         parameters_from_node = node.get_parameter_defaults()
         parameters_from_step = step.get_parameter_defaults(include_flags=True)


### PR DESCRIPTION
No_output_timeout should be in runtime_config in create execution template.

Fixes https://github.com/valohai/roi/issues/5347