### PR TITLE
Do not serialize multiple-separator for parameters that do not support it

### DIFF
--- a/valohai_yaml/objs/parameter.py
+++ b/valohai_yaml/objs/parameter.py
@@ -83,7 +83,7 @@ class Parameter(Item):
         if self.multiple:
             data['multiple'] = data['multiple'].value
         else:
-            data.pop('multiple-separator', None)
+            data.pop('multiple_separator', None)
         return data
 
     def _validate_value(self, value: ValueAtomType, errors: List[str]) -> ValueAtomType:


### PR DESCRIPTION
This PR fixes a customer bug report. It is a cosmetic issue that has no impact on application functionality, as the emitted fields are simply ignored when reading the YAML file back.

Resolves #92.

Tests for yaml serialisation are on valohai-utils test suite; valohai-utils maintenance PR will follow. 