### PR TITLE
Pipeline Parameter Conversion

### DIFF
--- a/examples/pipeline-with-parameters-example.yaml
+++ b/examples/pipeline-with-parameters-example.yaml
@@ -15,6 +15,7 @@
         targets:
           - train.parameter.id
           - train_parallel.parameter.id
+        default: 123
     nodes:
       - name: train
         step: train_step


### PR DESCRIPTION
Resolves [Pipeline parameters issue](https://github.com/valohai/roi/issues/4500)

## Why does this pull request exist? 
While creating pipeline from valohai-cli (adhoc or not), pipeline parameters were not being included in payload.


## Changed made in this pull request
- Add parameters in payload
- Add pipeline parameters conversion function which converts parameters dict into config-expression structure