### PR TITLE
Add Makefile for development shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: help
+help:
+	@echo "check README for usage"
+
+.PHONY: dev
+dev:
+	pip install -e . -r requirements-test.txt pre-commit
+	pre-commit install
+
+.PHONY: lint
+lint:
+	pre-commit run --all-files
+
+.PHONY: test
+test:
+	pytest

--- a/README.md
+++ b/README.md
@@ -54,12 +54,11 @@ print(config.steps['cool step'].command)
 
 ```bash
 # setup development dependencies
-pip install -e . -r requirements-test.txt pre-commit
-pre-commit install
+make dev
 
 # run linting and type checks
-pre-commit run --all-files
+make lint
 
 # run tests
-pytest
+make test
 ```


### PR DESCRIPTION
Resolves #108

Use standard commands (dev, lint, test) for development – reduces the need to check the README for repository-specific commands.