### PR TITLE
Pipeline Parameters: use non-None falsy defaults as is in conversion

### DIFF
--- a/examples/pipeline-with-parameters-example.yaml
+++ b/examples/pipeline-with-parameters-example.yaml
@@ -7,6 +7,14 @@
     parameters:
       - name: id
         type: string
+      - name: param0-float
+        type: float
+      - name: param0-int
+        type: integer
+      - name: param0-string
+        type: string
+      - name: param0-flag
+        type: flag
 
 - pipeline:
     name: Example Pipeline with Parameters
@@ -16,6 +24,22 @@
           - train.parameter.id
           - train_parallel.parameter.id
         default: 123
+      - name: param0-float
+        targets:
+          - train.parameter.param0-float
+        default: 0.0
+      - name: param0-int
+        targets:
+          - train.parameter.param0-int
+        default: 0
+      - name: param0-string
+        targets:
+          - train.parameter.param0-string
+        default: ""
+      - name: param0-flag
+        targets:
+          - train.parameter.param0-flag
+        default: false
     nodes:
       - name: train
         step: train_step

--- a/tests/test_pipeline_conversion.py
+++ b/tests/test_pipeline_conversion.py
@@ -53,21 +53,22 @@ def test_pipeline_conversion_override_inputs(pipeline_overridden_config: Config)
 
 
 def test_pipeline_parameter_conversion(pipeline_with_parameters_config):
-    parameter_name = "id"
     for _name, pipe in pipeline_with_parameters_config.pipelines.items():
         result = PipelineConverter(
             config=pipeline_with_parameters_config,
             commit_identifier="latest",
         ).convert_pipeline(pipe)
-        assert isinstance(result["parameters"], dict)
-        assert result["parameters"][parameter_name]
+        for parameter_name in [param.name for param in pipe.parameters]:
+            assert isinstance(result["parameters"], dict)
+            assert result["parameters"][parameter_name]
 
-        parameter = result["parameters"][parameter_name]
-        assert parameter["config"]["targets"]
-        assert "target" not in parameter["config"]
-        assert isinstance(parameter["config"]["targets"], list)
+            parameter = result["parameters"][parameter_name]
+            assert parameter["config"]["targets"]
+            assert "target" not in parameter["config"]
+            assert isinstance(parameter["config"]["targets"], list)
 
-        # When pipeline parameter has no default value, the expression should be empty
-        parameter_config = next(param for param in pipe.parameters if param.name == parameter_name)
-        expression_value = parameter_config.default if parameter_config.default else ""
-        assert parameter["expression"] == expression_value
+            # When pipeline parameter has no default value, the expression should be empty
+            parameter_config = next(param for param in pipe.parameters if param.name == parameter_name)
+            expression_value = parameter_config.default if parameter_config.default is not None else ""
+            assert parameter["expression"] == expression_value
+            assert type(parameter["expression"]) == type(expression_value)

--- a/tests/test_pipeline_parameters.py
+++ b/tests/test_pipeline_parameters.py
@@ -13,10 +13,9 @@ def test_programmatic_pipeline_parameters():
 
 def test_pipeline_parameters(pipeline_with_parameters_config):
     pipe = pipeline_with_parameters_config.pipelines['Example Pipeline with Parameters']
-    assert len(pipe.parameters) == 1
-    param = pipe.parameters[0]
+    assert len(pipe.parameters) > 0
+    param = next(param for param in pipe.parameters if param.name == 'id')
     assert isinstance(param, PipelineParameter)
-    assert param.name == 'id'
     assert param.targets == [
         'train.parameter.id',
         'train_parallel.parameter.id',
@@ -26,8 +25,8 @@ def test_pipeline_parameters(pipeline_with_parameters_config):
 @pytest.mark.parametrize('name', ('Short hand parameter target', 'Short hand parameter target 2'))
 def test_pipeline_parameter_shorthand(pipeline_with_parameters_config, name):
     pipe = pipeline_with_parameters_config.pipelines[name]
-    assert len(pipe.parameters) == 1
-    param = pipe.parameters[0]
+    assert len(pipe.parameters) > 0
+    param = next(param for param in pipe.parameters if param.name == 'id')
     assert isinstance(param, PipelineParameter)
     assert param.name == 'id'
     assert param.targets == ['train.parameter.id']

--- a/valohai_yaml/pipelines/conversion.py
+++ b/valohai_yaml/pipelines/conversion.py
@@ -53,7 +53,7 @@ class PipelineConverter:
         """Convert a pipeline parameter to a config-expression payload."""
         return {
             "config": {**parameter.serialize()},
-            "expression": parameter.default if parameter.default else "",
+            "expression": parameter.default if parameter.default is not None else "",
         }
 
     def convert_node(self, node: Node) -> ConvertedObject:


### PR DESCRIPTION
fixes #110 

Falsy parameter defaults were mistakenly cleaned into empty strings by #107 