### PR TITLE
Validating empty values as int/float gives more specific error

### DIFF
--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -12,19 +12,40 @@ def test_minmax(case):
     param.validate(5)
 
 
-@pytest.mark.parametrize("case", ("5.3", "hello"))
-def test_integer(case):
+@pytest.mark.parametrize(
+    "case, message",
+    [
+        ("5.3", "5.3 is not an integer"),
+        ("hello", "hello is not an integer"),
+        (True, "True is not an integer"),
+        (False, "False is not an integer"),
+        (None, "No value supplied"),
+        ("", "No value supplied"),
+    ],
+)
+def test_integer(case, message):
     param = Parameter(name="test", type="integer")
-    with pytest.raises(ValidationErrors):
+    with pytest.raises(ValidationErrors) as exc_info:
         param.validate(case)
+    assert list(exc_info.value) == [message]
     param.validate(5)
 
 
-@pytest.mark.parametrize("case", ("hello",))
-def test_float(case):
+@pytest.mark.parametrize(
+    "case, message",
+    [
+        ("hello", "hello is not a floating-point number"),
+        (True, "True is not a floating-point number"),
+        (False, "False is not a floating-point number"),
+        (None, "No value supplied"),
+        ("", "No value supplied"),
+    ],
+)
+def test_float(case, message):
     param = Parameter(name="test", type="float")
-    with pytest.raises(ValidationErrors):
+    with pytest.raises(ValidationErrors) as exc_info:
         param.validate(case)
+    assert list(exc_info.value) == [message]
     param.validate(1.5)
 
 

--- a/valohai_yaml/objs/parameter.py
+++ b/valohai_yaml/objs/parameter.py
@@ -113,12 +113,18 @@ class Parameter(Item):
             try:
                 value = int(str(value), 10)
             except ValueError:
-                errors.append(f"{value} is not an integer")
+                if value == "":
+                    errors.append("No value supplied")
+                else:
+                    errors.append(f"{value} is not an integer")
         elif self.type == "float":
             try:
                 value = float(str(value))
             except ValueError:
-                errors.append(f"{value} is not a floating-point number")
+                if value == "":
+                    errors.append("No value supplied")
+                else:
+                    errors.append(f"{value} is not a floating-point number")
         return value
 
     def validate(self, value: ValueType) -> ValueType:
@@ -134,6 +140,9 @@ class Parameter(Item):
 
         if not self.multiple and isinstance(value, (list, tuple)):
             errors.append("Only a single value is allowed")
+
+        if value is None:
+            errors.append("No value supplied")
 
         for atom in listify(value):
             if isinstance(atom, list):  # type guard


### PR DESCRIPTION
The current errors have confusing grammar for empty values. E.g. "is not an integer".