### PR TITLE
Do not keep empty Node `override` in serialized output

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-from valohai_yaml.objs import Config, DeploymentNode
+from valohai_yaml.objs import Config, DeploymentNode, ExecutionNode
 
 
 def test_pipeline_valid(pipeline_config: Config):
@@ -80,3 +80,12 @@ def test_empty_actions_not_serialized(pipeline_config: Config):
     assert train_node
     train_node.actions.clear()
     assert 'actions' not in train_node.serialize()
+
+
+def test_empty_override_not_serialized(pipeline_config: Config):
+    pl = pipeline_config.pipelines["My medium pipeline"]
+    train_node = pl.get_node_by(name='train')
+    assert isinstance(train_node, ExecutionNode)
+    assert train_node and train_node.override
+    train_node.override = None
+    assert 'override' not in train_node.serialize()

--- a/valohai_yaml/objs/pipelines/execution_node.py
+++ b/valohai_yaml/objs/pipelines/execution_node.py
@@ -4,7 +4,7 @@ from valohai_yaml.lint import LintResult
 from valohai_yaml.objs.pipelines.node import ErrorAction, Node
 from valohai_yaml.objs.pipelines.node_action import NodeAction
 from valohai_yaml.objs.pipelines.override import Override
-from valohai_yaml.types import LintContext, NodeOverrideDict
+from valohai_yaml.types import LintContext, NodeOverrideDict, SerializedDict
 
 
 class ExecutionNode(Node):
@@ -57,3 +57,9 @@ class ExecutionNode(Node):
             in self.override.parameters.items()
             if parameter.default is not None
         }
+
+    def serialize(self) -> SerializedDict:
+        ser = dict(super().serialize())
+        if not ser.get('override'):
+            ser.pop('override', None)
+        return ser


### PR DESCRIPTION
Analogue of 641bc3b89e4518a105c447e36028db432c6aa19a.