### PR TITLE
Refactor execution resources to a reference

### DIFF
--- a/valohai_yaml/schema/endpoint.yaml
+++ b/valohai_yaml/schema/endpoint.yaml
@@ -49,30 +49,11 @@ properties:
     additionalProperties: false
     properties:
       cpu:
-        type: object
-        description: CPU resource requirements and limits in vCPU counts e.g. 0.1 is 10% of one CPU.
-        additionalProperties: false
-        properties:
-          min:
-            type: number
-          max:
-            type: number
+        "$ref": "./workflow-resource-cpu.json"
       memory:
-        type: object
-        description: Memory requirements and limits in MB e.g. 100 is 100 MB.
-        additionalProperties: false
-        properties:
-          min:
-            type: number
-          max:
-            type: number
+        "$ref": "./workflow-resource-memory.json"
       devices:
-        type: object
-        description: "Devices required e.g. 'nvidia.com/gpu: 1' for one NVIDIA GPU."
-        patternProperties:
-          "^.+$":
-            type: number
-            minimum: 1
+        "$ref": "./workflow-resource-devices.json"
 oneOf:
   - required:
       - server-command

--- a/valohai_yaml/schema/workflow-resource-cpu.yaml
+++ b/valohai_yaml/schema/workflow-resource-cpu.yaml
@@ -1,0 +1,8 @@
+type: object
+description: CPU resource requirements and limits in vCPU counts e.g. 0.1 is 10% of one CPU.
+additionalProperties: false
+properties:
+  min:
+    type: number
+  max:
+    type: number

--- a/valohai_yaml/schema/workflow-resource-devices.yaml
+++ b/valohai_yaml/schema/workflow-resource-devices.yaml
@@ -1,0 +1,6 @@
+type: object
+description: "Devices required e.g. 'nvidia.com/gpu: 1' for one NVIDIA GPU."
+patternProperties:
+  "^.+$":
+    type: number
+    minimum: 1

--- a/valohai_yaml/schema/workflow-resource-memory.yaml
+++ b/valohai_yaml/schema/workflow-resource-memory.yaml
@@ -1,0 +1,8 @@
+type: object
+description: Memory requirements and limits in MB e.g. 100 is 100 MB.
+additionalProperties: false
+properties:
+  min:
+    type: number
+  max:
+    type: number


### PR DESCRIPTION
Refs valohai/meta#275

Prepare for reusing the resource definition in the Kubernetes worker configuration to avoid copy/paste – at the moment, these two look identical.

If they later turn out to have different requirements, will then refactor to separate definitions.