### PR TITLE
Add optional source-path Step option

### DIFF
--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -34,8 +34,23 @@ def test_command_override(example1_config):
 
 def test_nonexistent_interpolation_keys():
     empty_parameter_map = ParameterMap(parameters={}, values={})
-    interp_command = build_command(['Where are the ${shell_unicorns}? The {parameters} are here!'], empty_parameter_map)
+    interp_command = build_command(
+        ['Where are the ${shell_unicorns}? The {parameters} are here!'],
+        empty_parameter_map,
+    )
     assert interp_command == ['Where are the ${shell_unicorns}? The  are here!']
+
+
+def test_interpolate_special():
+    empty_parameter_map = ParameterMap(parameters={}, values={})
+    interp_command = build_command(
+        ['python {source-path}'],
+        empty_parameter_map,
+        special_interpolations={
+            'source-path': 'foo.py',
+        },
+    )
+    assert interp_command == ['python foo.py']
 
 
 parameter_test_values = {

--- a/valohai_yaml/schema/step.yaml
+++ b/valohai_yaml/schema/step.yaml
@@ -12,6 +12,10 @@ properties:
       - type: array
         items:
           type: string
+  source-path:
+    description: >
+      The original source file that this step comes from, relative to this config file.
+    type: string
   name:
     type: string
     description: The unique name for this step.


### PR DESCRIPTION
This is to support changing the Step's source file with `vh yaml step foo.py` invocations, which is implemented later in valohai-utils.

There are no blockers to merge this, as it is a completely optional field.