### PR TITLE
Use proper dict type definitions

### DIFF
--- a/valohai_yaml/objs/utils.py
+++ b/valohai_yaml/objs/utils.py
@@ -41,7 +41,7 @@ def check_type_and_listify(
 
 def check_type_and_dictify(source: Optional[Iterable[Any]], type: Type[T], attr: str) -> OrderedDictType[str, T]:
     """Check that all items in the `source` iterable are of the type `type` and map them into an OrderedDict."""
-    out = OrderedDict()  # type: OrderedDict[str, T]
+    out: OrderedDict[str, T] = OrderedDict()
     if source is None:
         return out
 
@@ -53,7 +53,7 @@ def check_type_and_dictify(source: Optional[Iterable[Any]], type: Type[T], attr:
 
 
 def serialize_into(
-    dest,  # type: OrderedDict[str, Any] # noqa: ANN001
+    dest: OrderedDict[str, Any],
     key: str,
     value: Any,
     *,


### PR DESCRIPTION
Related to #119 

Support for Python 3.7 dropped, so proper types can be used instead of comments.