### PR TITLE
Omit None parameters

### DIFF
--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -100,3 +100,15 @@ def test_parameter_value_with_falsy_values(example1_config):
         ],
     )
     assert command[0] == "env ds='' eps=0 runrunrun"
+
+
+def test_parameter_omit_with_none_value(example1_config):
+    command = example1_config.steps["run training"].build_command(
+        parameter_values={
+            "num-epochs": None,
+        },
+        command=[
+            "echo {parameters}; echo {parameter:num-epochs}",
+        ],
+    )
+    assert "num-epochs" not in command[0]

--- a/tests/test_step_parsing.py
+++ b/tests/test_step_parsing.py
@@ -73,18 +73,19 @@ def test_boolean_pass_as_param_parse(boolean_param_pass_as_config):
     step = boolean_param_pass_as_config.steps["test"]
     # "naughty" has `pass-false-as` so it's always emitted unless explicitly true
     assert step.build_command({"case-insensitive": True}) == [
-        "foo --ignore-case --naughty=not-naughty",
+        "foo --ignore-case",
     ]
     assert step.build_command({"case-insensitive": False}) == [
-        "foo --case-sensitive --naughty=not-naughty",
-    ]
-    assert step.build_command({"nice": True, "naughty": True}) == [
-        "foo --case-sensitive --behave-nice",
-    ]
-    assert step.build_command({"nice": False, "naughty": True}) == [
         "foo --case-sensitive",
     ]
-    assert step.build_command({}) == ["foo --case-sensitive --naughty=not-naughty"]
+    assert step.build_command({"nice": True, "naughty": True}) == [
+        "foo --behave-nice",
+    ]
+    assert step.build_command({"nice": False, "naughty": True}) == [
+        "foo",
+    ]
+    # None values should be omitted, use boolean values to bring parameters in use.
+    assert step.build_command({}) == ["foo"]
 
 
 def test_optional_default_param_parse(optional_default_param_config):

--- a/valohai_yaml/objs/parameter_map.py
+++ b/valohai_yaml/objs/parameter_map.py
@@ -1,6 +1,6 @@
-from typing import Any, List, Mapping, Optional
+from typing import List, Mapping, Optional
 
-from valohai_yaml.objs.parameter import Parameter
+from valohai_yaml.objs.parameter import Parameter, ValueType
 
 
 class ParameterMap:
@@ -10,14 +10,14 @@ class ParameterMap:
         self,
         *,
         parameters: Mapping[str, Parameter],
-        values: Mapping[str, Any],
+        values: Mapping[str, Optional[ValueType]],
     ) -> None:
         self.parameters = parameters
         self.values = values
 
     def build_parameters(self) -> List[str]:
         """
-        Build the CLI command line from the parameter values.
+        Build the CLI command line from the parameter values. Omit parameters with None value.
 
         :return: list of CLI strings -- not escaped!
         """
@@ -29,4 +29,6 @@ class ParameterMap:
     def build_parameter_by_name(self, name: str) -> Optional[List[str]]:
         param = self.parameters[name]
         value = self.values.get(param.name)
+        if value is None:
+            return None
         return param.format_cli(value)

--- a/valohai_yaml/objs/step.py
+++ b/valohai_yaml/objs/step.py
@@ -9,7 +9,7 @@ from valohai_yaml.objs.base import Item
 from valohai_yaml.objs.environment_variable import EnvironmentVariable
 from valohai_yaml.objs.input import Input
 from valohai_yaml.objs.mount import Mount
-from valohai_yaml.objs.parameter import Parameter
+from valohai_yaml.objs.parameter import Parameter, ValueType
 from valohai_yaml.objs.parameter_map import ParameterMap
 from valohai_yaml.objs.utils import (
     check_type_and_dictify,
@@ -129,7 +129,7 @@ class Step(Item):
 
     def build_command(
         self,
-        parameter_values: Dict[str, Any],
+        parameter_values: Dict[str, Optional[ValueType]],
         command: Optional[Union[List[str], str]] = None,
     ) -> List[str]:
         """


### PR DESCRIPTION
Users should be able to omit parameters fully. Empty string can be a valid value so it cannot be used as a signal for omitting but we need to use None value or some other means.
