### PR TITLE
Add stop-condition field to Step and Task objects/yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "jsonschema>=4.0",
     "PyYAML",
+    "leval>=1.1.1",
 ]
 
 [project.scripts]

--- a/tests/error_examples/step-stop-condition.yaml
+++ b/tests/error_examples/step-stop-condition.yaml
@@ -1,0 +1,5 @@
+- step:
+    name: no-stop
+    command: echo "i will not stop"
+    image: alpine/alpine
+    stop-condition: stop me if you can

--- a/tests/error_examples/task-stop-condition.yaml
+++ b/tests/error_examples/task-stop-condition.yaml
@@ -1,0 +1,10 @@
+- step:
+    name: no-stop-step
+    command: echo "i might be stoppable"
+    image: alpine/alpine
+- task:
+    name: no-stop
+    step: no-stop-step
+    type: grid_search
+    parameters: []
+    stop-condition: "can't stop me now"

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -2,7 +2,11 @@ from itertools import chain
 
 import pytest
 
-from tests.utils import get_error_example_path, get_warning_example_path
+from tests.utils import (
+    get_error_example_path,
+    get_valid_example_path,
+    get_warning_example_path,
+)
 from valohai_yaml.lint import lint_file
 
 
@@ -52,3 +56,36 @@ def test_invalid_indentation(file, expected_message):
     assert any(
         expected_message in message for message in messages
     ), messages  # pragma: no branch
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        "step-stop-condition.yaml",
+        "task-stop-condition.yaml",
+    ],
+)
+def test_expression_lint_ok(file_path):
+    items = lint_file(get_valid_example_path(file_path))
+    assert items.is_valid(), [
+        item["message"] for item in chain(items.hints, items.errors)
+    ]
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_message",
+    [
+        (
+            "step-stop-condition.yaml",
+            "Step no-stop, `stop-condition` is not a valid expression:",
+        ),
+        (
+            "task-stop-condition.yaml",
+            "Task no-stop, `stop-condition` is not a valid expression:",
+        ),
+    ],
+)
+def test_expression_lint_fail(file_path, expected_message):
+    items = lint_file(get_error_example_path(file_path))
+    messages = [item["message"] for item in chain(items.hints, items.errors)]
+    assert any(expected_message in message for message in messages), messages

--- a/tests/valid_examples/step-stop-condition.yaml
+++ b/tests/valid_examples/step-stop-condition.yaml
@@ -1,0 +1,5 @@
+- step:
+    name: can-stop
+    command: echo "i will stop"
+    image: alpine/alpine
+    stop-condition: stop > 1

--- a/tests/valid_examples/task-stop-condition.yaml
+++ b/tests/valid_examples/task-stop-condition.yaml
@@ -1,0 +1,10 @@
+- step:
+    name: can-stop
+    command: echo "i will stop"
+    image: alpine/alpine
+- task:
+    name: can-stop
+    step: can-stop
+    type: grid_search
+    parameters: []
+    stop-condition: stop > 1

--- a/valohai_yaml/schema/step.yaml
+++ b/valohai_yaml/schema/step.yaml
@@ -85,3 +85,5 @@ properties:
         "$ref": "./workflow-resource-memory.json"
       devices:
         "$ref": "./workflow-resource-devices.json"
+  stop-condition:
+    type: string

--- a/valohai_yaml/schema/task.yaml
+++ b/valohai_yaml/schema/task.yaml
@@ -37,3 +37,5 @@ properties:
     type: array
     items:
       "$ref": "./variant-param.json"
+  stop-condition:
+    type: string

--- a/valohai_yaml/utils/lint.py
+++ b/valohai_yaml/utils/lint.py
@@ -1,9 +1,17 @@
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable, Optional
+
+from leval.rewriter_evaluator import RewriterEvaluator
+from leval.universe.verifier import VerifierUniverse
 
 from valohai_yaml.types import LintContext
 
 if TYPE_CHECKING:
     from valohai_yaml.lint import LintResult
+
+
+class _KeywordRewriterEvaluator(RewriterEvaluator):
+    def rewrite_keyword(self, kw: str) -> str:
+        return f"_{kw}"
 
 
 def lint_iterables(
@@ -17,3 +25,24 @@ def lint_iterables(
         for item in iterable:
             if hasattr(item, "lint"):
                 item.lint(lint_result, context)
+
+
+def lint_expression(
+    lint_result: "LintResult",
+    context: LintContext,
+    field_name: str,
+    expression: Optional[str],
+) -> None:
+    if expression is None:
+        return
+
+    universe = VerifierUniverse()
+    evl = _KeywordRewriterEvaluator(universe, max_depth=8)
+    object_type = context["object_type"]
+    try:
+        evl.evaluate_expression(expression)
+    except Exception as e:
+        lint_result.add_error(
+            f"{object_type.capitalize()} {context[object_type].name}, "
+            f"`{field_name}` is not a valid expression: {e}",
+        )


### PR DESCRIPTION
Resolves #125

The field will be linted as well by trying to parse it.

The field is a simple string value, so it doesn't get its own item/object type. It is part of the Step or Task object, and linting is delegated to a utility function.