### PR TITLE
Kebab-case task properties and make task type validation more lenient

### DIFF
--- a/examples/task-example.yaml
+++ b/examples/task-example.yaml
@@ -46,7 +46,7 @@
 - task:
     step: run training
     name: task 4 logspace
-    type: random_search
+    type: RANDOM-SEARCH # will be normalized
     execution-batch-size: 42
     execution-count: 420
     optimization-target-metric: goodness

--- a/examples/task-example.yaml
+++ b/examples/task-example.yaml
@@ -47,6 +47,10 @@
     step: run training
     name: task 4 logspace
     type: random_search
+    execution-batch-size: 42
+    execution-count: 420
+    optimization-target-metric: goodness
+    optimization-target-value: 7.2
     parameters:
       - name: A
         style: logspace

--- a/tests/test_schemata.py
+++ b/tests/test_schemata.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from valohai_yaml.validation import SCHEMATA_DIRECTORY
+
+
+def test_schemata_has_no_underscores():
+    for yaml_path in Path(SCHEMATA_DIRECTORY).rglob("*.yaml"):
+        with yaml_path.open("r", encoding="utf-8") as f:
+            for lineno, line in enumerate(f, 1):
+                clean_line = line.partition("#")[0].strip()
+                if clean_line.endswith(":") and "_" in clean_line:
+                    raise AssertionError(
+                        f"Underscore in YAML key in {yaml_path!r}:{lineno}: {line!r}",
+                    )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -11,3 +11,11 @@ def test_tasks_parameters(task_config: Config):
         if len(task.parameters) > 0:
             assert task.parameters[0].name == "A"
             assert isinstance(task.parameters[0].style, VariantParameterStyle)
+
+
+def test_task_additional_fields(task_config: Config):
+    task = task_config.tasks["task 4 logspace"]
+    assert task.execution_batch_size == 42
+    assert task.execution_count == 420
+    assert task.optimization_target_metric == "goodness"
+    assert task.optimization_target_value == 7.2

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,4 +1,5 @@
 from valohai_yaml.objs import Config, Task
+from valohai_yaml.objs.task import TaskType
 from valohai_yaml.objs.variant_parameter import VariantParameterStyle
 
 
@@ -19,3 +20,4 @@ def test_task_additional_fields(task_config: Config):
     assert task.execution_count == 420
     assert task.optimization_target_metric == "goodness"
     assert task.optimization_target_value == 7.2
+    assert task.type == TaskType.RANDOM_SEARCH

--- a/valohai_yaml/objs/task.py
+++ b/valohai_yaml/objs/task.py
@@ -75,8 +75,7 @@ class Task(Item):
     def parse(cls, data: Any) -> Task:
         kwargs = data.copy()
         kwargs["parameters"] = consume_array_of(kwargs, "parameters", VariantParameter)
-        kwargs["stop_condition"] = kwargs.pop("stop-condition", None)
-        inst = cls(**kwargs)
+        inst = cls(**{key.replace("-", "_"): value for key, value in kwargs.items()})
         inst._original_data = data
         return inst
 

--- a/valohai_yaml/objs/task.py
+++ b/valohai_yaml/objs/task.py
@@ -29,7 +29,7 @@ class TaskType(Enum):
             return TaskType.GRID_SEARCH
         if isinstance(value, TaskType):
             return value
-        value = str(value).lower()
+        value = str(value).lower().replace("-", "_")
         return TaskType(value)
 
 

--- a/valohai_yaml/schema/task.yaml
+++ b/valohai_yaml/schema/task.yaml
@@ -20,12 +20,6 @@ properties:
     type: string
   type:
     type: string
-    enum:
-      - bayesian_tpe
-      - distributed
-      - grid_search
-      - manual_search
-      - random_search
   name:
     type: string
     description: The unique name for this task.

--- a/valohai_yaml/schema/task.yaml
+++ b/valohai_yaml/schema/task.yaml
@@ -8,14 +8,14 @@ properties:
   step:
     type: string
     description: The step to run with.
-  execution_count:
+  execution-count:
     type: integer
-  execution_batch_size:
+  execution-batch-size:
     type: integer
-  optimization_target_metric:
+  optimization-target-metric:
     type: string
-  optimization_target_value:
-    type: float
+  optimization-target-value:
+    type: number
   engine:
     type: string
   type:


### PR DESCRIPTION
* Primarily: Fixes #129 by changing the inadvertently `snake_case`d keys to `kebab-case` to match the rest of our schema. As discussed in that issue, this should be safe to change now, before it's too late.
* Secondarily: Removes the enumeration of task types from the schema; since `TaskType` itself already has lenient parsing for them, we should let that happen.
* Tertiarily: Adds a test to prevent us from adding more underscores into the schema in the future.

