### PR TITLE
Order bayesian-only props for stable error snapshot

### DIFF
--- a/tests/__snapshots__/test_validation.ambr
+++ b/tests/__snapshots__/test_validation.ambr
@@ -185,9 +185,9 @@
 # name: test_warning_examples_cli[nonsensical-task-bits.yaml]
   '''
   >>> nonsensical-task-bits.yaml
-  warning: optimization_target_value only makes sense for Bayesian TPE tasks
-  ------------------------------------------------------------
   warning: optimization_target_metric only makes sense for Bayesian TPE tasks
+  ------------------------------------------------------------
+  warning: optimization_target_value only makes sense for Bayesian TPE tasks
   ------------------------------------------------------------
   *** 0 errors, 2 warnings
   

--- a/valohai_yaml/objs/task.py
+++ b/valohai_yaml/objs/task.py
@@ -14,11 +14,11 @@ from valohai_yaml.types import LintContext
 from valohai_yaml.utils.lint import lint_expression
 
 # Properties that only make sense for Bayesian tasks.
-BAYESIAN_ONLY_PROPS = {
-    "optimization_target_value",
-    "optimization_target_metric",
+BAYESIAN_ONLY_PROPS = (
     "engine",
-}
+    "optimization_target_metric",
+    "optimization_target_value",
+)
 
 
 class TaskType(Enum):


### PR DESCRIPTION
Mini followup on #136 – since `BAYESIAN_ONLY_PROPS` was a set, its iteration order wasn't stable.