### PR TITLE
Add error-pipeline as then-action for node actions

### DIFF
--- a/examples/pipeline-example.yaml
+++ b/examples/pipeline-example.yaml
@@ -130,6 +130,13 @@
               - node-complete
             if: [a, b, c]
             then: noop
+      - name: accuracy-error
+        type: execution
+        step: Test model
+        actions:
+          - when: node-complete
+            if: "metadata.accuracy <= .8"
+            then: error-pipeline
     edges:
       - [train.output.model, validate.input.model]
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -74,6 +74,13 @@ def test_action_pipeline(pipeline_config: Config):
         "then": ["noop"],
         "when": ["node-complete", "node-starting"],
     }
+    error_node = pl.get_node_by(name="accuracy-error")
+    assert error_node
+    assert error_node.actions[0].get_data() == {
+        "if": ["metadata.accuracy <= .8"],
+        "then": ["error-pipeline"],
+        "when": ["node-complete"],
+    }
 
 
 def test_empty_actions_not_serialized(pipeline_config: Config):

--- a/valohai_yaml/objs/pipelines/node_action.py
+++ b/valohai_yaml/objs/pipelines/node_action.py
@@ -14,6 +14,7 @@ WELL_KNOWN_WHENS = {
 WELL_KNOWN_THENS = {
     "noop",  # For testing
     "stop-pipeline",
+    "error-pipeline",
 }
 
 


### PR DESCRIPTION
This action will be used to fail the parent pipeline based on its nodes' actions.