### PR TITLE
Parse and serialize Step resources as WorkloadResources

### DIFF
--- a/tests/test_serialize_step.py
+++ b/tests/test_serialize_step.py
@@ -1,7 +1,7 @@
 def test_serialize_workload_resources(step_with_resources):
     """Must not flatten workload resource data."""
     config = step_with_resources
-    resources = config.steps["contains kubernetes resources"].resources
+    resources = config.steps["contains kubernetes resources"].serialize()["resources"]
 
     assert isinstance(resources, dict), "Resources should be defined."
     assert "cpu" in resources, "Resources should contain data."
@@ -10,7 +10,9 @@ def test_serialize_workload_resources(step_with_resources):
 def test_serialize_partial_resources(step_with_partial_resources):
     """Serialized data only contains keys found in the config."""
     config = step_with_partial_resources
-    resources = config.steps["contains partial workload resources"].resources
+    resources = config.steps["contains partial workload resources"].serialize()[
+        "resources"
+    ]
 
     assert "min" in resources["cpu"]
     assert "max" not in resources["cpu"]

--- a/tests/test_workload_resources.py
+++ b/tests/test_workload_resources.py
@@ -22,6 +22,10 @@ RESOURCE_DATA = {
     "devices": {"foo": 1, "bar": 2},
 }
 
+RESOURCE_DATA_WITH_DELIBERATE_EMPTY_DEVICES: dict = {
+    "devices": {},
+}
+
 
 def test_create_resources():
     """All YAML properties are correctly parsed into the object."""
@@ -36,7 +40,7 @@ def test_create_resources():
     assert resources.memory.max == 20
 
     assert isinstance(resources.devices, ResourceDevices)
-    assert resources.devices.get_data() == {"foo": 1, "bar": 2}
+    assert resources.devices.get_data_or_none() == {"foo": 1, "bar": 2}
 
 
 def test_missing_resources():
@@ -53,10 +57,17 @@ def test_missing_resources():
     assert resources.memory.max is None
 
     assert resources.devices is not None
-    assert resources.devices.devices == {}
+    assert resources.devices.devices is None
 
     # the empty dict-initialized resources also serialize back into an empty dict
     assert resources.serialize() == {}
+
+
+def test_cleared_devices():
+    resources = WorkloadResources.parse(RESOURCE_DATA_WITH_DELIBERATE_EMPTY_DEVICES)
+
+    assert resources.devices.devices == {}
+    assert resources.serialize() == RESOURCE_DATA_WITH_DELIBERATE_EMPTY_DEVICES
 
 
 @pytest.mark.parametrize(

--- a/tests/test_workload_resources.py
+++ b/tests/test_workload_resources.py
@@ -43,9 +43,20 @@ def test_missing_resources():
     """None of the workload properties are required."""
     resources = WorkloadResources.parse(OrderedDict([]))
 
-    assert resources.cpu is None
-    assert resources.memory is None
-    assert resources.devices is None
+    # Subresources are created with None/empty leaf values
+    assert resources.cpu is not None
+    assert resources.cpu.min is None
+    assert resources.cpu.max is None
+
+    assert resources.memory is not None
+    assert resources.memory.min is None
+    assert resources.memory.max is None
+
+    assert resources.devices is not None
+    assert resources.devices.devices == {}
+
+    # the empty dict-initialized resources also serialize back into an empty dict
+    assert resources.serialize() == {}
 
 
 @pytest.mark.parametrize(
@@ -62,7 +73,7 @@ def test_missing_sub_resources(resource_name, missing_key):
     resources = create_resources(resource_name, missing_key)
 
     for this_resource_name, sub_resources in resources.get_data().items():
-        for name, value in sub_resources.get_data().items():
+        for name, value in sub_resources.items():
             if this_resource_name == resource_name and name == missing_key:
                 assert value is None
             else:

--- a/valohai_yaml/objs/step.py
+++ b/valohai_yaml/objs/step.py
@@ -71,7 +71,7 @@ class Step(Item):
 
         self.time_limit = time_limit
         self.no_output_timeout = no_output_timeout
-        self.resources = resources
+        self.resources = resources if resources else WorkloadResources.parse({})
         self.stop_condition = stop_condition
 
     @classmethod
@@ -84,6 +84,7 @@ class Step(Item):
         kwargs["source_path"] = kwargs.pop("source-path", None)
         kwargs["stop_condition"] = kwargs.pop("stop-condition", None)
         kwargs["upload_store"] = kwargs.pop("upload-store", None)
+        kwargs["resources"] = WorkloadResources.parse(kwargs.pop("resources", {}))
         inst = cls(**kwargs)
         inst._original_data = data
         return inst
@@ -121,7 +122,7 @@ class Step(Item):
             ("icon", self.icon),
             ("category", self.category),
             ("source-path", self.source_path),
-            ("resources", self.resources),
+            ("resources", self.resources.get_data() or None),
             ("stop-condition", self.stop_condition),
             ("upload-store", self.upload_store),
         ]:


### PR DESCRIPTION
Step will now always populate its `resources` attribute with a `WorkloadResources` object, which will additionally always populate its full structure down to the value fields so you can query it easily. Empty resources will serialise back into nothing when outputting back into YAML.