### PR TITLE
🔨 Use `uv` for handling packages if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
+UV := $(shell command -v uv)
+ifdef UV
+	PIP_INSTALL = uv pip install
+else
+	PIP_INSTALL = pip install
+endif
+
 .PHONY: help
 help:
 	@echo "check README for usage"
 
 .PHONY: dev
 dev:
-	pip install -e . -r requirements-test.txt pre-commit
+	$(PIP_INSTALL) -e . -r requirements-test.txt pre-commit
 	pre-commit install
 
 .PHONY: lint


### PR DESCRIPTION
If the `uv` command is found, uses `uv pip` to install the dependencies.

Standard `pip` still used as a fallback.

If `uv` is available, `make dev` will use that even if the virtual environment was originally created with `virtualenv` (seemed to work just fine).