### PR TITLE
Support list as pipeline parameter expression

### DIFF
--- a/examples/pipeline-with-parameters-example.yaml
+++ b/examples/pipeline-with-parameters-example.yaml
@@ -15,6 +15,12 @@
         type: string
       - name: param0-flag
         type: flag
+      - name: listings
+        default: [all_harbors, all_uploads, all_uploads2]
+        type: string
+        multiple: separate
+        multiple-separator: ","
+        optional: false
 
 - pipeline:
     name: Example Pipeline with Parameters
@@ -45,6 +51,11 @@
         targets:
           - train.parameter.param0-flag
         default: false
+      - name: listings
+        targets:
+          - train.parameter.listings
+          - train_parallel.parameter.listings
+        default: [abc, def, ghi]
     nodes:
       - name: train
         step: train_step

--- a/tests/__snapshots__/test_validation.ambr
+++ b/tests/__snapshots__/test_validation.ambr
@@ -104,9 +104,9 @@
 # name: test_bad_examples_cli[step-missing-required-properties.yaml]
   '''
   >>> step-missing-required-properties.yaml
-  error:   Oneof validation on step.command.oneOf: 8 is not valid under any of the given schemas (1.step.command)
-  ------------------------------------------------------------
   error:   Type validation on step.image.type: True is not of type 'string' (0.step.image)
+  ------------------------------------------------------------
+  error:   Oneof validation on step.command.oneOf: 8 is not valid under any of the given schemas (1.step.command)
   ------------------------------------------------------------
   error:   Required validation on step.required: 'command' is a required property (0.step)
   ------------------------------------------------------------

--- a/tests/test_pipeline_conversion.py
+++ b/tests/test_pipeline_conversion.py
@@ -81,4 +81,30 @@ def test_pipeline_parameter_conversion(pipeline_with_parameters_config):
                 }
             else:
                 assert parameter["expression"] == expression_value
-                assert type(parameter["expression"]) == type(expression_value)
+                assert type(parameter["expression"]) is type(expression_value)
+
+
+def test_pipeline_parameter_conversion_with_args(pipeline_with_parameters_config):
+    pipeline = pipeline_with_parameters_config.pipelines["Example Pipeline with Parameters"]
+    args = {
+        "param0-float": 1.5,
+        "param0-int": 3,
+        "param0-string": "iceberg",
+        "param0-flag": True,
+        "listings": ["msg", "pfa"],
+    }
+    result = PipelineConverter(
+        config=pipeline_with_parameters_config,
+        commit_identifier="latest",
+        parameter_arguments=args,
+    ).convert_pipeline(pipeline)
+    params = result["parameters"]
+
+    assert params["param0-float"]["expression"] == 1.5
+    assert params["param0-int"]["expression"] == 3
+    assert params["param0-string"]["expression"] == "iceberg"
+    assert params["param0-flag"]["expression"]
+    assert params["listings"]["expression"] == {
+        "style": "single",
+        "rules": {"value": ["msg", "pfa"]},
+    }

--- a/tests/test_pipeline_conversion.py
+++ b/tests/test_pipeline_conversion.py
@@ -73,9 +73,12 @@ def test_pipeline_parameter_conversion(pipeline_with_parameters_config):
             # When pipeline parameter has no default value, the expression should be empty
             parameter_config = next(param for param in pipe.parameters if param.name == parameter_name)
             expression_value = parameter_config.default if parameter_config.default is not None else ""
-            # When pipeline parameter is list it should be converted to a comma separated string
+            # When pipeline parameter is list it should be converted to a variant parameter
             if isinstance(expression_value, list):
-                assert parameter["expression"] == ",".join(expression_value)
+                assert parameter["expression"] == {
+                    "style": "single",
+                    "rules": {"value": expression_value},
+                }
             else:
                 assert parameter["expression"] == expression_value
                 assert type(parameter["expression"]) == type(expression_value)

--- a/tests/test_pipeline_conversion.py
+++ b/tests/test_pipeline_conversion.py
@@ -73,5 +73,9 @@ def test_pipeline_parameter_conversion(pipeline_with_parameters_config):
             # When pipeline parameter has no default value, the expression should be empty
             parameter_config = next(param for param in pipe.parameters if param.name == parameter_name)
             expression_value = parameter_config.default if parameter_config.default is not None else ""
-            assert parameter["expression"] == expression_value
-            assert type(parameter["expression"]) == type(expression_value)
+            # When pipeline parameter is list it should be converted to a comma separated string
+            if isinstance(expression_value, list):
+                assert parameter["expression"] == ",".join(expression_value)
+            else:
+                assert parameter["expression"] == expression_value
+                assert type(parameter["expression"]) == type(expression_value)

--- a/valohai_yaml/objs/pipelines/pipeline_parameter.py
+++ b/valohai_yaml/objs/pipelines/pipeline_parameter.py
@@ -19,7 +19,7 @@ class PipelineParameter(Item):
         name: str,
         targets: Optional[Union[List[str], str]] = None,
         value: Optional[str] = None,
-        default: Optional[str] = None,
+        default: Optional[Union[List[str], str]] = None,
         category: Optional[str] = None,
         description: Optional[str] = None,
     ) -> None:

--- a/valohai_yaml/pipelines/conversion.py
+++ b/valohai_yaml/pipelines/conversion.py
@@ -12,6 +12,7 @@ from valohai_yaml.objs import (
 from valohai_yaml.objs.pipelines.override import Override
 
 ConvertedObject = Dict[str, Any]
+ExpressionValue = Union[str, int, bool, float, list]
 
 
 class ConvertedPipeline(TypedDict):
@@ -45,7 +46,7 @@ class PipelineConverter:
         """Convert a pipeline parameter to a config-expression payload."""
         return {
             "config": {**parameter.serialize()},
-            "expression": parameter.default if parameter.default is not None else "",
+            "expression": self.convert_expression(parameter.default) if parameter.default is not None else "",
         }
 
     def convert_node(self, node: Node) -> ConvertedObject:
@@ -102,3 +103,8 @@ class PipelineConverter:
         }
 
         return node_data
+
+    def convert_expression(self, expression: ExpressionValue) -> ExpressionValue:
+        if isinstance(expression, list):
+            return ",".join(expression)
+        return expression

--- a/valohai_yaml/pipelines/conversion.py
+++ b/valohai_yaml/pipelines/conversion.py
@@ -12,7 +12,16 @@ from valohai_yaml.objs import (
 from valohai_yaml.objs.pipelines.override import Override
 
 ConvertedObject = Dict[str, Any]
-ExpressionValue = Union[str, int, bool, float, list]
+
+
+class VariantExpression(TypedDict):
+    """Variant expression template."""
+
+    style: str
+    rules: Dict[str, Any]
+
+
+ExpressionValue = Union[str, int, bool, float, VariantExpression]
 
 
 class ConvertedPipeline(TypedDict):
@@ -104,7 +113,10 @@ class PipelineConverter:
 
         return node_data
 
-    def convert_expression(self, expression: ExpressionValue) -> ExpressionValue:
+    def convert_expression(self, expression: Union[ExpressionValue, list]) -> ExpressionValue:
         if isinstance(expression, list):
-            return ",".join(expression)
+            return VariantExpression(
+                style="single",
+                rules={"value": expression},
+            )
         return expression


### PR DESCRIPTION
Resolves [300](https://github.com/valohai/valohai-cli/issues/300)
## Changes in this PR:
- Added convert expression function to convert YAML lists as list expressions, which behaves the same as pipelines on the web application
- Add pipeline parameters support for PipelineConverter