### PR TITLE
Parameter categories

### DIFF
--- a/examples/example1.yaml
+++ b/examples/example1.yaml
@@ -35,11 +35,13 @@
         description: How many supervised samples are used
         type: integer
         default: 60000
+        category: Samples
 
       - name: unlabeled-samples
         description: How many unsupervised samples are used
         type: integer
         default: 60000
+        category: Samples
 
       - name: encoder-layers
         description: List of layers for f
@@ -61,10 +63,12 @@
         type: string
         default: SELECT * FROM mytable
         widget: sql
+        category: Database
 
       - name: output-alias
         type: string
         default: my-alias
+        category: Output
         widget:
           type: DatumAlias
           settings:

--- a/examples/pipeline-with-parameters-example.yaml
+++ b/examples/pipeline-with-parameters-example.yaml
@@ -25,6 +25,7 @@
           - train_parallel.parameter.id
         default: 123
         category: Apples
+        description: The ID of the thing to train
       - name: param0-float
         targets:
           - train.parameter.param0-float

--- a/examples/pipeline-with-parameters-example.yaml
+++ b/examples/pipeline-with-parameters-example.yaml
@@ -24,18 +24,22 @@
           - train.parameter.id
           - train_parallel.parameter.id
         default: 123
+        category: Apples
       - name: param0-float
         targets:
           - train.parameter.param0-float
         default: 0.0
+        category: Apples
       - name: param0-int
         targets:
           - train.parameter.param0-int
         default: 0
+        category: Oranges
       - name: param0-string
         targets:
           - train.parameter.param0-string
         default: ""
+        category: Oranges
       - name: param0-flag
         targets:
           - train.parameter.param0-flag

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from valohai_yaml.commands import build_command
 from valohai_yaml.objs.parameter_map import ParameterMap
 
@@ -110,3 +112,21 @@ def test_parameter_omit_with_none_value(example1_config):
         ],
     )
     assert "num-epochs" not in command[0]
+
+
+def test_parameter_categories(example1_config):
+    pbc = defaultdict(set)
+    for param in example1_config.steps["run training"].parameters.values():
+        pbc[param.category].add(param.name)
+    assert pbc == {
+        None: {
+            "decoder-spec",
+            "denoising-cost-x",
+            "encoder-layers",
+            "num-epochs",
+            "seed",
+        },
+        "Database": {"sql-query"},
+        "Output": {"output-alias"},
+        "Samples": {"unlabeled-samples", "labeled-samples"},
+    }

--- a/tests/test_pipeline_parameters.py
+++ b/tests/test_pipeline_parameters.py
@@ -21,6 +21,7 @@ def test_pipeline_parameters(pipeline_with_parameters_config):
         "train_parallel.parameter.id",
     ]
     assert param.category == "Apples"
+    assert param.description == "The ID of the thing to train"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pipeline_parameters.py
+++ b/tests/test_pipeline_parameters.py
@@ -20,6 +20,7 @@ def test_pipeline_parameters(pipeline_with_parameters_config):
         "train.parameter.id",
         "train_parallel.parameter.id",
     ]
+    assert param.category == "Apples"
 
 
 @pytest.mark.parametrize(

--- a/valohai_yaml/objs/parameter.py
+++ b/valohai_yaml/objs/parameter.py
@@ -54,6 +54,7 @@ class Parameter(Item):
         multiple: Optional[Union[str, MultipleMode]] = None,
         multiple_separator: str = ",",
         widget: Optional[ParameterWidget] = None,
+        category: Optional[str] = None,
     ) -> None:
         self.name = name
         self.type = type
@@ -68,6 +69,7 @@ class Parameter(Item):
         self.multiple = MultipleMode.cast(multiple)
         self.multiple_separator = str(multiple_separator or ",")
         self.widget = widget
+        self.category = str(category) if category else None
 
         self.default = listify(default) if self.multiple else default
         if self.type == "flag":

--- a/valohai_yaml/objs/pipelines/pipeline_parameter.py
+++ b/valohai_yaml/objs/pipelines/pipeline_parameter.py
@@ -21,10 +21,12 @@ class PipelineParameter(Item):
         value: Optional[str] = None,
         default: Optional[str] = None,
         category: Optional[str] = None,
+        description: Optional[str] = None,
     ) -> None:
         self.name = name
         self.default = default if value is None else value
         self.category = str(category) if category else None
+        self.description = str(description) if description else None
         if not targets:
             self.targets = []
         elif isinstance(targets, str):

--- a/valohai_yaml/objs/pipelines/pipeline_parameter.py
+++ b/valohai_yaml/objs/pipelines/pipeline_parameter.py
@@ -20,9 +20,11 @@ class PipelineParameter(Item):
         targets: Optional[Union[List[str], str]] = None,
         value: Optional[str] = None,
         default: Optional[str] = None,
+        category: Optional[str] = None,
     ) -> None:
         self.name = name
         self.default = default if value is None else value
+        self.category = str(category) if category else None
         if not targets:
             self.targets = []
         elif isinstance(targets, str):

--- a/valohai_yaml/schema/param-item.yaml
+++ b/valohai_yaml/schema/param-item.yaml
@@ -6,6 +6,9 @@ properties:
   description:
     type: string
     description: Describes the parameter. This is shown as a help text in the user interface.
+  category:
+    type: string
+    description: Free-form category for the parameter. Shown in the user interface.
   pass-as:
     type: string
     default: "--{name}={value}"

--- a/valohai_yaml/schema/pipeline-param.yaml
+++ b/valohai_yaml/schema/pipeline-param.yaml
@@ -17,3 +17,6 @@ properties:
   category:
     type: string
     description: Free-form category for the parameter. Shown in the user interface.
+  description:
+    type: string
+    description: Describes the parameter. This is shown as a help text in the user interface.

--- a/valohai_yaml/schema/pipeline-param.yaml
+++ b/valohai_yaml/schema/pipeline-param.yaml
@@ -14,3 +14,6 @@ properties:
     type: string
   default:
     description: The default value for the pipeline parameter.
+  category:
+    type: string
+    description: Free-form category for the parameter. Shown in the user interface.


### PR DESCRIPTION
This PR adds YAML support for categorizing parameters and pipeline parameters. An empty string will be considered a `null` category.

While doing that, it also adds `description` to pipeline parameters, for parity with regular parameters.