### PR TITLE
Elide default reuse-executions and edge-merge-mode values from serialization results

### DIFF
--- a/tests/test_edge_merge_mode.py
+++ b/tests/test_edge_merge_mode.py
@@ -7,15 +7,13 @@ def test_edge_override_mode(edge_merge_mode_config):
     pipeline = config.pipelines["check-edge-merge-mode"]
     assert len(pipeline.nodes) == 3
     converted_pipeline = PipelineConverter(config=config, commit_identifier="latest").convert_pipeline(pipeline)
-    node0 = converted_pipeline["nodes"][0]
-    node1 = converted_pipeline["nodes"][1]
-    node2 = converted_pipeline["nodes"][2]
+    nodes = converted_pipeline["nodes"]
 
-    # override-mode not defined
-    assert node0["edge-merge-mode"] == EdgeMergeMode.REPLACE.value
+    # override-mode not defined, so it's elided
+    assert "edge-merge-mode" not in nodes[0]
 
-    # override-mode = replace
-    assert node1["edge-merge-mode"] == EdgeMergeMode.REPLACE.value
+    # override-mode = replace, but that's the default so not included
+    assert "edge-merge-mode" not in nodes[1]
 
     # override-mode = append
-    assert node2["edge-merge-mode"] == EdgeMergeMode.APPEND.value
+    assert nodes[2]["edge-merge-mode"] == EdgeMergeMode.APPEND.value

--- a/valohai_yaml/objs/pipelines/edge_merge_mode.py
+++ b/valohai_yaml/objs/pipelines/edge_merge_mode.py
@@ -15,5 +15,8 @@ class EdgeMergeMode(Enum):
         if isinstance(value, EdgeMergeMode):
             return value
         if not value:
-            return EdgeMergeMode.REPLACE
+            return DEFAULT_EDGE_MERGE_MODE
         return EdgeMergeMode(str(value).lower())
+
+
+DEFAULT_EDGE_MERGE_MODE = EdgeMergeMode.REPLACE

--- a/valohai_yaml/objs/pipelines/node.py
+++ b/valohai_yaml/objs/pipelines/node.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Union
 
 from valohai_yaml.lint import LintResult
 from valohai_yaml.objs.base import Item
+from valohai_yaml.objs.pipelines.edge_merge_mode import DEFAULT_EDGE_MERGE_MODE
 from valohai_yaml.objs.pipelines.node_action import NodeAction
 from valohai_yaml.objs.utils import check_type_and_listify, consume_array_of
 from valohai_yaml.types import LintContext, SerializedDict
@@ -82,6 +83,8 @@ class Node(Item):
     def get_data(self) -> SerializedDict:
         data = super().get_data()
         data["on_error"] = data["on_error"].value
+        if data.get("edge_merge_mode") == DEFAULT_EDGE_MERGE_MODE:  # Elide default
+            del data["edge_merge_mode"]
         return data
 
     def __repr__(self) -> str:  # noqa: D105

--- a/valohai_yaml/objs/pipelines/pipeline.py
+++ b/valohai_yaml/objs/pipelines/pipeline.py
@@ -44,6 +44,8 @@ class Pipeline(Item):
         data = super().get_data()
         if not data.get("parameters"):
             del data["parameters"]
+        if not data.get("reuse_executions"):  # elide default "False"
+            del data["reuse_executions"]
         return data
 
     def lint(self, lint_result: LintResult, context: LintContext) -> None:


### PR DESCRIPTION
Keeps the serialized data more minimal.