### PR TITLE
✅ Sort selected test snapshot lines

### DIFF
--- a/tests/__snapshots__/test_validation.ambr
+++ b/tests/__snapshots__/test_validation.ambr
@@ -1,167 +1,152 @@
 # serializer version: 1
 # name: test_bad_examples_cli[endpoint-names-invalid.yaml]
   '''
-  >>> endpoint-names-invalid.yaml
-  error:   Pattern validation on endpoint.name.pattern: 'Server-endpoint' does not match '^[a-z][a-z0-9-]+$' (0.endpoint.name)
-  ------------------------------------------------------------
-  error:   Pattern validation on endpoint.name.pattern: '3-server-endpoint' does not match '^[a-z][a-z0-9-]+$' (1.endpoint.name)
-  ------------------------------------------------------------
-  error:   Pattern validation on endpoint.name.pattern: 'server@endpoint' does not match '^[a-z][a-z0-9-]+$' (2.endpoint.name)
-  ------------------------------------------------------------
-  error:   Pattern validation on endpoint.name.pattern: 'wsgi_endpoint' does not match '^[a-z][a-z0-9-]+$' (3.endpoint.name)
-  ------------------------------------------------------------
   *** 4 errors, 0 warnings
-  
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  >>> endpoint-names-invalid.yaml
+  error:   Pattern validation on endpoint.name.pattern: '3-server-endpoint' does not match '^[a-z][a-z0-9-]+$' (1.endpoint.name)
+  error:   Pattern validation on endpoint.name.pattern: 'Server-endpoint' does not match '^[a-z][a-z0-9-]+$' (0.endpoint.name)
+  error:   Pattern validation on endpoint.name.pattern: 'server@endpoint' does not match '^[a-z][a-z0-9-]+$' (2.endpoint.name)
+  error:   Pattern validation on endpoint.name.pattern: 'wsgi_endpoint' does not match '^[a-z][a-z0-9-]+$' (3.endpoint.name)
   '''
 # ---
 # name: test_bad_examples_cli[input-name-too-long.yaml]
   '''
+  *** 1 errors, 0 warnings
+  ------------------------------------------------------------
   >>> input-name-too-long.yaml
   error:   Maxlength validation on step.inputs.name.maxLength: 'this-input-name-is-way-too-long-and-will-cause-the-validation-to-fail' is too long (0.step.inputs.0.name)
-  ------------------------------------------------------------
-  *** 1 errors, 0 warnings
-  
   '''
 # ---
 # name: test_bad_examples_cli[invalid-YAML-indentation.yaml]
   '''
+  *** 1 errors, 0 warnings
+  ------------------------------------------------------------
   >>> invalid-YAML-indentation.yaml
   error: Indentation Error at line 3, column 10
-  ------------------------------------------------------------
-  *** 1 errors, 0 warnings
-  
   '''
 # ---
 # name: test_bad_examples_cli[invalid-edge-parts.yaml]
   '''
+  *** 1 errors, 0 warnings
+  ------------------------------------------------------------
   >>> invalid-edge-parts.yaml
   error: Target specifier 'batch2.input' must have 3 parts (it has 2)
-  ------------------------------------------------------------
-  *** 1 errors, 0 warnings
-  
   '''
 # ---
 # name: test_bad_examples_cli[invalid-indentation-with-valid-YAML.yaml]
   '''
+  *** 1 errors, 0 warnings
+  ------------------------------------------------------------
+  ------------------------------------------------------------
   >>> invalid-indentation-with-valid-YAML.yaml
   error:   Type validation on step.type: None is not of type 'object' (0.step)
-  ------------------------------------------------------------
   hint: File contains valid YAML but there might be an indentation error in following configuration: 0.step
-  ------------------------------------------------------------
-  *** 1 errors, 0 warnings
-  
   '''
 # ---
 # name: test_bad_examples_cli[invalid-on-error-value.yaml]
   '''
+  *** 1 errors, 0 warnings
+  ------------------------------------------------------------
   >>> invalid-on-error-value.yaml
   error:   Anyof validation on pipeline.nodes.anyOf: {'name': 'train-with-errors', 'step': 'train', 'type': 'task', 'on-error': 'report-to-sentry'} is not valid under any of the given schemas (2.pipeline.nodes.1)
-  ------------------------------------------------------------
-  *** 1 errors, 0 warnings
-  
   '''
 # ---
 # name: test_bad_examples_cli[invalid-pipeline-with-override-example.yaml]
   '''
+  *** 3 errors, 0 warnings
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  ------------------------------------------------------------
   >>> invalid-pipeline-with-override-example.yaml
   error: Pipeline My overriden input pipeline node merged step base step: input training-labels-error does not exist in step
-  ------------------------------------------------------------
   error: Pipeline My overriden input pipeline node merged step base step: parameter d does not exist in step
-  ------------------------------------------------------------
   error: Pipeline My overriden input pipeline node overridden step secon step does not exist
-  ------------------------------------------------------------
-  *** 3 errors, 0 warnings
-  
   '''
 # ---
 # name: test_bad_examples_cli[invalid-shorthand-edge.yaml]
   '''
+  *** 1 errors, 0 warnings
+  ------------------------------------------------------------
   >>> invalid-shorthand-edge.yaml
   error: Malformed edge shorthand ['batch1.input.training-labels*']
-  ------------------------------------------------------------
-  *** 1 errors, 0 warnings
-  
   '''
 # ---
 # name: test_bad_examples_cli[invalid-upload-store-value.yaml]
   '''
+  *** 1 errors, 0 warnings
+  ------------------------------------------------------------
   >>> invalid-upload-store-value.yaml
   error:   Maxlength validation on step.upload-store.maxLength: 'This is a test string exactly with  65 characters long in length.' is too long (0.step.upload-store)
-  ------------------------------------------------------------
-  *** 1 errors, 0 warnings
-  
   '''
 # ---
 # name: test_bad_examples_cli[step-invalid-resources.yaml]
   '''
+  *** 1 errors, 0 warnings
+  ------------------------------------------------------------
   >>> step-invalid-resources.yaml
   error:   Type validation on step.resources.cpu.min.type: 'Not a number' is not of type 'number' (0.step.resources.cpu.min)
-  ------------------------------------------------------------
-  *** 1 errors, 0 warnings
-  
   '''
 # ---
 # name: test_bad_examples_cli[step-missing-required-properties.yaml]
   '''
-  >>> step-missing-required-properties.yaml
-  error:   Type validation on step.image.type: True is not of type 'string' (0.step.image)
-  ------------------------------------------------------------
-  error:   Oneof validation on step.command.oneOf: 8 is not valid under any of the given schemas (1.step.command)
-  ------------------------------------------------------------
-  error:   Required validation on step.required: 'command' is a required property (0.step)
-  ------------------------------------------------------------
-  error:   Required validation on step.required: 'name' is a required property (0.step)
-  ------------------------------------------------------------
   *** 4 errors, 0 warnings
-  
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  >>> step-missing-required-properties.yaml
+  error:   Oneof validation on step.command.oneOf: 8 is not valid under any of the given schemas (1.step.command)
+  error:   Required validation on step.required: 'command' is a required property (0.step)
+  error:   Required validation on step.required: 'name' is a required property (0.step)
+  error:   Type validation on step.image.type: True is not of type 'string' (0.step.image)
   '''
 # ---
 # name: test_bad_examples_cli[step-stop-condition.yaml]
   '''
+  *** 1 errors, 0 warnings
+  ------------------------------------------------------------
   >>> step-stop-condition.yaml
   error: Step no-stop, `stop-condition` is not a valid expression: invalid syntax (<expression>, line 1)
-  ------------------------------------------------------------
-  *** 1 errors, 0 warnings
-  
   '''
 # ---
 # name: test_bad_examples_cli[step-with-error-tasks.yaml]
   '''
-  >>> step-with-error-tasks.yaml
-  error:   Type validation on task.parameters.rules.type: None is not of type 'object' (1.task.parameters.0.rules)
-  ------------------------------------------------------------
-  error:   Type validation on task.parameters.name.type: None is not of type 'string' (2.task.parameters.0.name)
-  ------------------------------------------------------------
-  error:   Required validation on task.parameters.required: 'style' is a required property (2.task.parameters.0)
-  ------------------------------------------------------------
-  error:   Required validation on task.parameters.required: 'name' is a required property (5.task.parameters.0)
-  ------------------------------------------------------------
-  error:   Required validation on task.parameters.required: 'style' is a required property (5.task.parameters.0)
-  ------------------------------------------------------------
-  error:   Required validation on task.required: 'name' is a required property (1.task)
-  ------------------------------------------------------------
-  error:   Required validation on task.required: 'step' is a required property (4.task)
-  ------------------------------------------------------------
   *** 7 errors, 0 warnings
-  
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  ------------------------------------------------------------
+  >>> step-with-error-tasks.yaml
+  error:   Required validation on task.parameters.required: 'name' is a required property (5.task.parameters.0)
+  error:   Required validation on task.parameters.required: 'style' is a required property (2.task.parameters.0)
+  error:   Required validation on task.parameters.required: 'style' is a required property (5.task.parameters.0)
+  error:   Required validation on task.required: 'name' is a required property (1.task)
+  error:   Required validation on task.required: 'step' is a required property (4.task)
+  error:   Type validation on task.parameters.name.type: None is not of type 'string' (2.task.parameters.0.name)
+  error:   Type validation on task.parameters.rules.type: None is not of type 'object' (1.task.parameters.0.rules)
   '''
 # ---
 # name: test_bad_examples_cli[task-stop-condition.yaml]
   '''
+  *** 1 errors, 0 warnings
+  ------------------------------------------------------------
   >>> task-stop-condition.yaml
   error: Task no-stop, `stop-condition` is not a valid expression: EOL while scanning string literal (<expression>, line 1)
-  ------------------------------------------------------------
-  *** 1 errors, 0 warnings
-  
   '''
 # ---
 # name: test_bad_examples_cli[wrong-edge-merge-mode.yaml]
   '''
+  *** 1 errors, 0 warnings
+  ------------------------------------------------------------
   >>> wrong-edge-merge-mode.yaml
   error:   Anyof validation on pipeline.nodes.anyOf: {'name': 'bad-pn', 'type': 'execution', 'step': 'buzz', 'edge-merge-mode': 'boo-boo'} is not valid under any of the given schemas (1.pipeline.nodes.0)
-  ------------------------------------------------------------
-  *** 1 errors, 0 warnings
-  
   '''
 # ---
 # name: test_warning_examples_cli[invalid-numeric-parameter-default.yaml]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -17,7 +17,7 @@ from valohai_yaml import ValidationErrors, validate
 from valohai_yaml.__main__ import main
 
 
-def assert_validation_output(capsys, snapshot, yaml_path: str) -> bool:
+def assert_validation_output(capsys, snapshot, yaml_path: str, sort_output: bool = False) -> bool:
     out, err = capsys.readouterr()
     # Replace the path with just the filename,
     # so this is agnostic to where the tests are run from.
@@ -28,6 +28,9 @@ def assert_validation_output(capsys, snapshot, yaml_path: str) -> bool:
         "EOL while scanning string literal",
         out,
     )
+    # Optionally sort the lines to make the output deterministic.
+    if sort_output:
+        out = "\n".join(sorted(out.splitlines()))
     assert out == snapshot
     return True
 
@@ -50,7 +53,7 @@ def test_good_examples_cli(good_example_path):
 def test_bad_examples_cli(capsys, yaml_path, snapshot):
     """Test that bad examples don't validate via the CLI."""
     assert main([yaml_path]) == 1
-    assert assert_validation_output(capsys, snapshot, yaml_path)
+    assert assert_validation_output(capsys, snapshot, yaml_path, sort_output=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`test_validation` kept failing for me locally – the error messages are otherwise identical, but they appeared in a different order than in the snapshot.

Since the content of the validation error messages is what is important, it should be enough to just test that both contents have the same lines, no matter which order the messages are in.

Add optional sorting of the validation error results, so the order of the messages does not matter any more.
There are no functional changes to the validation tests in this PR.

The sorting could maybe have been made mandatory, but since the flakiness has only appeared in one of the tests, make it optional to fix just that test and leave the rest be. This can be changed if flakiness is found in other tests later.

The downside of this change is that the snapshot file is less human-readable. But I doubt anyone regularly reads those.

Snapshot before:
```
  >>> step-missing-required-properties.yaml
  error:   Type validation on step.image.type: True is not of type 'string' (0.step.image)
  ------------------------------------------------------------
  error:   Oneof validation on step.command.oneOf: 8 is not valid under any of the given schemas (1.step.command)
  ------------------------------------------------------------
  error:   Required validation on step.required: 'command' is a required property (0.step)
  ------------------------------------------------------------
  error:   Required validation on step.required: 'name' is a required property (0.step)
  ------------------------------------------------------------
  *** 4 errors, 0 warnings
```

Local error before:
```
  >>> step-missing-required-properties.yaml
  error:   Oneof validation on step.command.oneOf: 8 is not valid under any of the given schemas (1.step.command)
  ------------------------------------------------------------
  error:   Type validation on step.image.type: True is not of type 'string' (0.step.image)
  ------------------------------------------------------------
  error:   Required validation on step.required: 'command' is a required property (0.step)
  ------------------------------------------------------------
  error:   Required validation on step.required: 'name' is a required property (0.step)
  ------------------------------------------------------------
  *** 4 errors, 0 warnings
```

Snapshot and local test output after, with lines for a test sorted:
```
  *** 4 errors, 0 warnings
  ------------------------------------------------------------
  ------------------------------------------------------------
  ------------------------------------------------------------
  ------------------------------------------------------------
  >>> step-missing-required-properties.yaml
  error:   Oneof validation on step.command.oneOf: 8 is not valid under any of the given schemas (1.step.command)
  error:   Required validation on step.required: 'command' is a required property (0.step)
  error:   Required validation on step.required: 'name' is a required property (0.step)
  error:   Type validation on step.image.type: True is not of type 'string' (0.step.image)
```
