### PR TITLE
Become 0.47.1

### DIFF
--- a/valohai_yaml/__init__.py
+++ b/valohai_yaml/__init__.py
@@ -2,7 +2,7 @@ from valohai_yaml.excs import ValidationErrors
 from valohai_yaml.parsing import parse
 from valohai_yaml.validation import validate
 
-__version__ = "0.46.0"
+__version__ = "0.47.0"
 
 __all__ = [
     "ValidationErrors",

--- a/valohai_yaml/__init__.py
+++ b/valohai_yaml/__init__.py
@@ -2,7 +2,7 @@ from valohai_yaml.excs import ValidationErrors
 from valohai_yaml.parsing import parse
 from valohai_yaml.validation import validate
 
-__version__ = "0.47.0"
+__version__ = "0.47.1"
 
 __all__ = [
     "ValidationErrors",


### PR DESCRIPTION
Fixes version numbering in `__init__`.
