### PR TITLE
Allow reusing task's execution from yaml config

### DIFF
--- a/examples/task-example.yaml
+++ b/examples/task-example.yaml
@@ -61,6 +61,7 @@
           count: 4
           base: 10
           integerify: False
+    reuse-children: true
 
 - task:
     step: run training

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -38,3 +38,10 @@ def test_task_parameter_sets(task_config: Config):
         {"A": 72, "B": 42},
     ]
     assert task.type == TaskType.MANUAL_SEARCH
+
+
+def test_task_reuse_children(task_config: Config):
+    task = task_config.tasks["task 4 logspace"]
+    assert task.reuse_children is True
+    task2 = task_config.tasks["task 1 single"]
+    assert task2.reuse_children is False

--- a/valohai_yaml/objs/task.py
+++ b/valohai_yaml/objs/task.py
@@ -89,6 +89,7 @@ class Task(Item):
         engine: str | None = None,
         on_child_error: TaskOnChildError | None = None,
         stop_condition: str | None = None,
+        reuse_children: bool = False,
     ) -> None:
         self.name = name
         self.step = step
@@ -103,6 +104,7 @@ class Task(Item):
         self.engine = engine
         self.on_child_error = TaskOnChildError.cast(on_child_error)
         self.stop_condition = stop_condition
+        self.reuse_children = reuse_children
 
     @classmethod
     def parse(cls, data: Any) -> Task:

--- a/valohai_yaml/schema_data.py
+++ b/valohai_yaml/schema_data.py
@@ -625,10 +625,7 @@ register(
             },
             "reuse-children": {
                 "default": False,
-                "description": "Set to true to allow Valohai to automatically detect if the executions in"
-                "the task's executions could be reused from a previously successfully run executions.\n"
-                "Task's execution is considered unchanged when the data doesn't change "
-                "(inputs, command, commit hash, parameters, step's configuration).",
+                "description": "Whether to allow automatic reuse of previous successful executions.",
                 "type": "boolean",
             },
             "step": {"description": "The step to run with.", "type": "string"},

--- a/valohai_yaml/schema_data.py
+++ b/valohai_yaml/schema_data.py
@@ -623,6 +623,14 @@ register(
                 "items": {"$ref": "/schemas/variant-param"},
                 "type": "array",
             },
+            "reuse-children": {
+                "default": False,
+                "description": "Set to true to allow Valohai to automatically detect if the executions in"
+                "the task's executions could be reused from a previously successfully run executions.\n"
+                "Task's execution is considered unchanged when the data doesn't change "
+                "(inputs, command, commit hash, parameters, step's configuration).",
+                "type": "boolean",
+            },
             "step": {"description": "The step to run with.", "type": "string"},
             "stop-condition": {"type": "string"},
             "type": {"type": "string"},


### PR DESCRIPTION
Add property `reuse-executions` to task yaml definition