### PR TITLE
🔢🎛️ Serialize parameter widget definitions

### DIFF
--- a/tests/test_serialize_parameter.py
+++ b/tests/test_serialize_parameter.py
@@ -1,0 +1,40 @@
+import json
+
+from valohai_yaml.objs import Parameter
+from valohai_yaml.objs.parameter_widget import ParameterWidget
+
+
+def test_simple_widget_roundtrip():
+    param = Parameter(
+        name="query",
+        type="string",
+        widget=ParameterWidget(type="sql"),
+    )
+    as_data = param.get_data()
+    as_json = json.dumps(as_data)
+
+    re_data = json.loads(as_json)
+    parsed = Parameter.parse(re_data)
+    assert parsed.name == param.name
+    assert parsed.type == param.type
+    assert isinstance(parsed.widget, ParameterWidget)
+    assert parsed.widget.type == "sql"
+    assert parsed.widget.settings == {}
+
+
+def test_complex_widget_roundtrip():
+    param = Parameter(
+        name="query",
+        type="string",
+        widget=ParameterWidget(type="sql", settings={"language": "sql"}),
+    )
+    as_data = param.get_data()
+    as_json = json.dumps(as_data)
+
+    re_data = json.loads(as_json)
+    parsed = Parameter.parse(re_data)
+    assert parsed.name == param.name
+    assert parsed.type == param.type
+    assert isinstance(parsed.widget, ParameterWidget)
+    assert parsed.widget.type == "sql"
+    assert parsed.widget.settings == {"language": "sql"}

--- a/tests/test_serialize_step.py
+++ b/tests/test_serialize_step.py
@@ -1,3 +1,13 @@
+def test_serialize_step_parameter_with_widget(example1_config):
+    config = example1_config
+    parameters = config.steps["run training"].serialize()["parameters"]
+    output_alias_param = next((param for param in parameters if param["name"] == "output-alias"), None)
+
+    assert isinstance(output_alias_param, dict)
+    assert output_alias_param["widget"]["type"] == "datumalias"
+    assert output_alias_param["widget"]["settings"] == {"width": 123}
+
+
 def test_serialize_workload_resources(step_with_resources):
     """Must not flatten workload resource data."""
     config = step_with_resources

--- a/valohai_yaml/objs/parameter.py
+++ b/valohai_yaml/objs/parameter.py
@@ -89,6 +89,8 @@ class Parameter(Item):
             data["multiple"] = data["multiple"].value
         else:
             data.pop("multiple_separator", None)
+        if self.widget:
+            data["widget"] = self.widget.serialize()
         return data
 
     def _validate_value(self, value: ValueAtomType, errors: List[str]) -> ValueAtomType:


### PR DESCRIPTION
Refs https://github.com/valohai/roi/issues/9391

one might assume that `Parameter.get_data()` returns something that can be JSON serialized

but **not** when there is a widget definition

fix inside