### PR TITLE
📝 Add slug to runtime config preset property description

### DIFF
--- a/valohai_yaml/schema_data.py
+++ b/valohai_yaml/schema_data.py
@@ -623,7 +623,7 @@ register(
                 "type": "object",
             },
             "runtime-config-preset": {
-                "description": "The runtime configuration preset ID to use for this step.",
+                "description": "The runtime configuration preset ID or slug to use for this step.",
                 "type": "string",
             },
             "source-path": {


### PR DESCRIPTION
Resolves #145 

Mention slug in the schema doc for runtime config preset.

Also, editor did some reformatting of the schema data.

This is valid after https://github.com/valohai/roi/pull/9436 has been released.