### PR TITLE
📝 Add description to pipeline edges in JSON schema

### DIFF
--- a/valohai_yaml/objs/pipelines/edge.py
+++ b/valohai_yaml/objs/pipelines/edge.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from valohai_yaml.excs import ValidationError
 from valohai_yaml.lint import LintResult
+from valohai_yaml.objs.pipelines.types import edge_types
 from valohai_yaml.types import EdgeConfigurationDict, LintContext, SerializedDict
 from valohai_yaml.utils.node_socket_utils import split_socket_str
 
@@ -9,16 +10,6 @@ if TYPE_CHECKING:
     from valohai_yaml.objs import Pipeline
 
 from valohai_yaml.objs.base import Item
-
-edge_types = {
-    "input",
-    "output",
-    "parameter",
-    "metadata",
-    "file",
-    "dependency",
-    "environment-variable",
-}
 
 
 class Edge(Item):

--- a/valohai_yaml/objs/pipelines/types.py
+++ b/valohai_yaml/objs/pipelines/types.py
@@ -1,0 +1,9 @@
+edge_types = {
+    "input",
+    "output",
+    "parameter",
+    "metadata",
+    "file",
+    "dependency",
+    "environment-variable",
+}

--- a/valohai_yaml/schema_data.py
+++ b/valohai_yaml/schema_data.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 
+from valohai_yaml.objs.pipelines.types import edge_types
+
 SCHEMATA = {}
+
+edge_types_list = " | ".join(edge_types)
 
 
 def register(schema: dict) -> None:
@@ -477,6 +481,12 @@ register(
                 "items": {
                     "anyOf": [
                         {
+                            "description": (
+                                "A shorthand edge definition as a two-item array: [source, target]. "
+                                "Source and target format: `node-name.edge-type.edge-key`.<br>\n"
+                                f"Allowed edge types: {edge_types_list}.<br>\n"
+                                "Example: `[train-model.output.model.pkl, test-model.input.model]` "
+                            ),
                             "items": False,
                             "prefixItems": [{"type": "string"}, {"type": "string"}],
                             "title": "ShorthandEdge",
@@ -484,6 +494,11 @@ register(
                         },
                         {
                             "additionalProperties": False,
+                            "description": (
+                                "A full edge definition as an object with source, target and optional "
+                                "additional configuration. "
+                                "Same source and target format as in the shorthand edge definition."
+                            ),
                             "properties": {
                                 "configuration": {"type": "object"},
                                 "source": {"type": "string"},


### PR DESCRIPTION
The edge definition content is not defined by the schema – add a bit of extra information to help the user (so they don’t have to dig in the docs for the content).

Pick the edge types from the actual definition so they stay up to date automatically (move the definition to a separate `types` module to avoid complicated import chains).

The description in the documentation:

<img width="2326" height="1028" alt="89049" src="https://github.com/user-attachments/assets/e8cc4412-0dd0-4071-9e08-1d2a8b5983b7" />
