### PR TITLE
🔖 Add current release version to the schema documentation

### DIFF
--- a/valohai_yaml/utils/markdown_doc/doc_generator.py
+++ b/valohai_yaml/utils/markdown_doc/doc_generator.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from valohai_yaml.utils.markdown_doc.formatters import format_doc_content
 from valohai_yaml.utils.markdown_doc.parsers import parse_definitions, parse_top_level_item_refs
+from valohai_yaml.utils.version import get_current_version
 
 
 def generate_schema_doc(schema_dict: dict[str, Any]) -> str:
@@ -12,5 +13,6 @@ def generate_schema_doc(schema_dict: dict[str, Any]) -> str:
     """
     top_level_item_refs = list(parse_top_level_item_refs(schema_dict.get("items", {})))
     definitions = parse_definitions(schema_dict.get("$defs", {}), top_level_item_refs)
+    version = get_current_version()
 
-    return "\n".join(format_doc_content(top_level_item_refs, definitions))
+    return "\n".join(format_doc_content(top_level_item_refs, definitions, version))

--- a/valohai_yaml/utils/markdown_doc/formatters.py
+++ b/valohai_yaml/utils/markdown_doc/formatters.py
@@ -6,9 +6,15 @@ from typing import Any, Iterable, Iterator
 from valohai_yaml.utils.markdown_doc.types import Definition
 
 
-def format_doc_content(main_item_refs: Iterable[str], definitions: Iterator[Definition]) -> Iterator[str]:
+def format_doc_content(
+    main_item_refs: Iterable[str],
+    definitions: Iterator[Definition],
+    version: str,
+) -> Iterator[str]:
     """Format the documentation content to Markdown."""
     yield "# Valohai YAML Configuration Documentation\n"
+    yield f"_Valohai YAML version v{version}_\n\n"
+
     yield "## Top-level Properties\n"
 
     for ref in main_item_refs:

--- a/valohai_yaml/utils/version.py
+++ b/valohai_yaml/utils/version.py
@@ -1,0 +1,34 @@
+import subprocess
+
+from valohai_yaml import __version__
+
+
+def get_current_version() -> str:
+    """
+    Get the current version (based on latest release).
+
+    If there have been commits after the tagged release version,
+    a '+' is added to the version.
+    """
+    version = __version__
+    suffix = "+" if _has_changed_after_release(version) else ""
+    return f"{version}{suffix}"
+
+
+def _has_changed_after_release(version: str) -> bool:
+    """Check for commits after the given version tag."""
+    tag = f"v{version}"
+    try:
+        result = subprocess.run(
+            ["git", "rev-list", f"{tag}..HEAD", "--count"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        if result.returncode == 0:
+            commit_count = int(result.stdout.strip())
+            return commit_count > 0
+    except (subprocess.TimeoutExpired, ValueError, FileNotFoundError):
+        # could not determine, assume no changes
+        pass
+    return False


### PR DESCRIPTION
Make it easier to confirm you're using the correct version of the doc (and spec).

For devs, add an indication that the code has changed since the latest release. (This might be overkill, but…)

Add the release version to the beginning of the schema doc:

<img width="1868" height="216" alt="21945" src="https://github.com/user-attachments/assets/adfabfae-7580-4093-a9ca-818f3f564016" />

----

In case the code has changed after the release (so there _might_ be schema changes, although this is not checked), that is indicated in the version:

<img width="1852" height="222" alt="54113" src="https://github.com/user-attachments/assets/e7f4a8ef-806e-4f03-a55d-a47d191db73e" />
