### PR TITLE
🔖 Make 'dev version' indicator more explicit

### DIFF
--- a/valohai_yaml/utils/markdown_doc/formatters.py
+++ b/valohai_yaml/utils/markdown_doc/formatters.py
@@ -13,7 +13,7 @@ def format_doc_content(
 ) -> Iterator[str]:
     """Format the documentation content to Markdown."""
     yield "# Valohai YAML Configuration Documentation\n"
-    yield f"_Valohai YAML version v{version}_\n\n"
+    yield f"_Valohai YAML v{version}_\n\n"
 
     yield "## Top-level Properties\n"
 

--- a/valohai_yaml/utils/version.py
+++ b/valohai_yaml/utils/version.py
@@ -8,10 +8,10 @@ def get_current_version() -> str:
     Get the current version (based on latest release).
 
     If there have been commits after the tagged release version,
-    a '+' is added to the version.
+    a '+dev' is added to the version.
     """
     version = __version__
-    suffix = "+" if _has_changed_after_release(version) else ""
+    suffix = "+dev" if _has_changed_after_release(version) else ""
     return f"{version}{suffix}"
 
 


### PR DESCRIPTION
Follow up #194 – improve the version marking based on review comments.

- Instead of just `+`, use a more clear `+dev` to indicate that there are commits after the official release.
- Remove unnecessary `version` from the doc (`v` already signifies a version).
