### PR TITLE
Ensure all Items and Enums are re-exported

### DIFF
--- a/tests/test_objs_reexports.py
+++ b/tests/test_objs_reexports.py
@@ -1,0 +1,59 @@
+import enum
+import importlib
+import inspect
+import pkgutil
+
+import valohai_yaml.objs
+import valohai_yaml.objs.pipelines
+
+
+def _collect_public_names(package):
+    """Collect all public class/enum names defined in a package's submodules."""
+    public_names = {}
+    package_path = package.__path__
+    package_prefix = package.__name__ + "."
+
+    for _importer, modname, _ispkg in pkgutil.walk_packages(package_path, prefix=package_prefix):
+        module = importlib.import_module(modname)
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if name.startswith("_"):
+                continue
+            # Only include classes actually defined in this module (not imported from elsewhere)
+            if obj.__module__ != module.__name__:
+                continue
+            # Only include classes and enums, not e.g. TypeVars
+            if not (isinstance(obj, type) and (issubclass(obj, (valohai_yaml.objs.Item, enum.Enum)) or name == "Item")):
+                continue
+            public_names[name] = module.__name__
+    return public_names
+
+
+def test_objs_reexports_all_public_classes():
+    """All public classes/enums in valohai_yaml.objs submodules are re-exported from __init__."""
+    defined = _collect_public_names(valohai_yaml.objs)
+    exported = set(valohai_yaml.objs.__all__)
+    missing = set(defined) - exported
+    assert not missing, (
+        f"The following classes are defined in valohai_yaml.objs submodules "
+        f"but not listed in valohai_yaml.objs.__all__: "
+        f"{', '.join(f'{name} (from {defined[name]})' for name in sorted(missing))}"
+    )
+    # Also verify they're actually importable from the package
+    for name in exported:
+        assert hasattr(valohai_yaml.objs, name), f"{name} is in __all__ but not importable from valohai_yaml.objs"
+
+
+def test_pipelines_reexports_all_public_classes():
+    """All public classes/enums in valohai_yaml.objs.pipelines submodules are re-exported from __init__."""
+    defined = _collect_public_names(valohai_yaml.objs.pipelines)
+    exported = set(valohai_yaml.objs.pipelines.__all__)
+    missing = set(defined) - exported
+    assert not missing, (
+        f"The following classes are defined in valohai_yaml.objs.pipelines submodules "
+        f"but not listed in valohai_yaml.objs.pipelines.__all__: "
+        f"{', '.join(f'{name} (from {defined[name]})' for name in sorted(missing))}"
+    )
+    for name in exported:
+        assert hasattr(valohai_yaml.objs.pipelines, name), (
+            f"{name} is in __all__ but not importable from valohai_yaml.objs.pipelines"
+        )

--- a/valohai_yaml/objs/__init__.py
+++ b/valohai_yaml/objs/__init__.py
@@ -1,33 +1,70 @@
+from valohai_yaml.objs.base import Item
 from valohai_yaml.objs.config import Config
 from valohai_yaml.objs.deployment import Deployment
 from valohai_yaml.objs.endpoint import Endpoint
+from valohai_yaml.objs.environment_variable import EnvironmentVariable
 from valohai_yaml.objs.file import File
+from valohai_yaml.objs.input import DownloadIntent, Input, KeepDirectories
 from valohai_yaml.objs.mount import Mount
-from valohai_yaml.objs.parameter import Parameter
+from valohai_yaml.objs.parameter import MultipleMode, Parameter
+from valohai_yaml.objs.parameter_map import ParameterMap
+from valohai_yaml.objs.parameter_widget import ParameterWidget
 from valohai_yaml.objs.pipelines.deployment_node import DeploymentNode
 from valohai_yaml.objs.pipelines.edge import Edge
+from valohai_yaml.objs.pipelines.edge_merge_mode import EdgeMergeMode
 from valohai_yaml.objs.pipelines.execution_node import ExecutionNode
-from valohai_yaml.objs.pipelines.node import Node
+from valohai_yaml.objs.pipelines.node import ErrorAction, Node
+from valohai_yaml.objs.pipelines.node_action import NodeAction
+from valohai_yaml.objs.pipelines.override import Override
 from valohai_yaml.objs.pipelines.pipeline import Pipeline
 from valohai_yaml.objs.pipelines.pipeline_parameter import PipelineParameter
 from valohai_yaml.objs.pipelines.task_node import TaskNode
 from valohai_yaml.objs.step import Step
-from valohai_yaml.objs.task import Task
+from valohai_yaml.objs.task import Task, TaskOnChildError, TaskType
+from valohai_yaml.objs.variant_parameter import VariantParameter, VariantParameterStyle
+from valohai_yaml.objs.workload_resources import (
+    ResourceCPU,
+    ResourceDevices,
+    ResourceMemory,
+    WorkloadResourceItem,
+    WorkloadResources,
+)
 
 __all__ = [
     "Config",
     "Deployment",
     "DeploymentNode",
+    "DownloadIntent",
     "Edge",
+    "EdgeMergeMode",
     "Endpoint",
+    "EnvironmentVariable",
+    "ErrorAction",
     "ExecutionNode",
     "File",
+    "Input",
+    "Item",
+    "KeepDirectories",
     "Mount",
+    "MultipleMode",
     "Node",
+    "NodeAction",
+    "Override",
     "Parameter",
+    "ParameterMap",
+    "ParameterWidget",
     "Pipeline",
-    "Step",
-    "TaskNode",
     "PipelineParameter",
+    "ResourceCPU",
+    "ResourceDevices",
+    "ResourceMemory",
+    "Step",
     "Task",
+    "TaskNode",
+    "TaskOnChildError",
+    "TaskType",
+    "VariantParameter",
+    "VariantParameterStyle",
+    "WorkloadResourceItem",
+    "WorkloadResources",
 ]

--- a/valohai_yaml/objs/pipelines/__init__.py
+++ b/valohai_yaml/objs/pipelines/__init__.py
@@ -1,0 +1,24 @@
+from valohai_yaml.objs.pipelines.deployment_node import DeploymentNode
+from valohai_yaml.objs.pipelines.edge import Edge
+from valohai_yaml.objs.pipelines.edge_merge_mode import EdgeMergeMode
+from valohai_yaml.objs.pipelines.execution_node import ExecutionNode
+from valohai_yaml.objs.pipelines.node import ErrorAction, Node
+from valohai_yaml.objs.pipelines.node_action import NodeAction
+from valohai_yaml.objs.pipelines.override import Override
+from valohai_yaml.objs.pipelines.pipeline import Pipeline
+from valohai_yaml.objs.pipelines.pipeline_parameter import PipelineParameter
+from valohai_yaml.objs.pipelines.task_node import TaskNode
+
+__all__ = [
+    "DeploymentNode",
+    "Edge",
+    "EdgeMergeMode",
+    "ErrorAction",
+    "ExecutionNode",
+    "Node",
+    "NodeAction",
+    "Override",
+    "Pipeline",
+    "PipelineParameter",
+    "TaskNode",
+]

--- a/valohai_yaml/objs/pipelines/override.py
+++ b/valohai_yaml/objs/pipelines/override.py
@@ -4,10 +4,11 @@ import copy
 from collections import OrderedDict
 from typing import TYPE_CHECKING
 
-from valohai_yaml.objs import Mount, Parameter
 from valohai_yaml.objs.base import Item
 from valohai_yaml.objs.environment_variable import EnvironmentVariable
 from valohai_yaml.objs.input import Input
+from valohai_yaml.objs.mount import Mount
+from valohai_yaml.objs.parameter import Parameter
 from valohai_yaml.objs.step import Step, parse_common_step_properties
 from valohai_yaml.objs.utils import (
     check_type_and_dictify,


### PR DESCRIPTION
We were re-exporting an arbitrary selection of `objs` from the top-level package; this ensures all of them are, with a test to ensure it in the future.