### PR TITLE
Do not serialize empty edge configs or default node error actions

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -163,6 +163,33 @@ def test_pipeline_runtime_config_preset_override_without_step_preset(
     assert node.override.runtime_config_preset == "preset-xyz789"
 
 
+def test_default_on_error_not_serialized(pipeline_config: Config):
+    pl = pipeline_config.pipelines["My little pipeline"]
+    node = pl.get_node_by(name="batch1")
+    assert node and node.on_error == ErrorAction.STOP_ALL
+    assert "on-error" not in node.serialize()
+
+
+def test_non_default_on_error_serialized(pipeline_with_retried_execution_config: Config):
+    node = pipeline_with_retried_execution_config.pipelines["pipe"].nodes[0]
+    assert node.on_error == ErrorAction.RETRY
+    assert node.serialize()["on-error"] == "retry"
+
+
+def test_empty_edge_configuration_not_serialized(pipeline_config: Config):
+    pl = pipeline_config.pipelines["My little pipeline"]
+    edge = pl.edges[0]
+    edge.configuration = {}
+    assert "configuration" not in edge.serialize()
+
+
+def test_non_empty_edge_configuration_serialized(pipeline_config: Config):
+    pl = pipeline_config.pipelines["My little pipeline"]
+    edge = pl.edges[0]
+    edge.configuration = {"foo": "bar"}
+    assert edge.serialize()["configuration"] == {"foo": "bar"}
+
+
 def test_pipeline_runtime_config_preset_override_requires_environment():
     """Lint fails when runtime config preset is overridden without environment."""
     path = get_error_example_path("pipeline-with-preset-override-without-environment.yaml")

--- a/tests/test_pipeline_conversion.py
+++ b/tests/test_pipeline_conversion.py
@@ -119,13 +119,11 @@ def test_pipeline_commit_conversion(pipeline_with_different_commit_config: Confi
     assert result["nodes"] == [
         {
             "name": "preprocess",
-            "on-error": "stop-all",
             "type": "execution",
             "template": {"commit": "library:generic-preprocessors/csv-into-parquet", "step": "parquetify"},
         },
         {
             "name": "mangle",
-            "on-error": "stop-all",
             "type": "execution",
             "template": {
                 "commit": "102dsgkmr4",

--- a/valohai_yaml/objs/pipelines/edge.py
+++ b/valohai_yaml/objs/pipelines/edge.py
@@ -65,11 +65,13 @@ class Edge(Item):
         return super().parse(data)
 
     def get_data(self) -> SerializedDict:
-        return {
+        data: SerializedDict = {
             "source": self.source,
             "target": self.target,
-            "configuration": self.configuration,
         }
+        if self.configuration:
+            data["configuration"] = self.configuration
+        return data
 
     def get_expanded(self) -> dict[str, Any]:
         """Get the "expanded" form of this edge."""

--- a/valohai_yaml/objs/pipelines/node.py
+++ b/valohai_yaml/objs/pipelines/node.py
@@ -86,7 +86,9 @@ class Node(Item):
 
     def get_data(self) -> SerializedDict:
         data = super().get_data()
-        data["on_error"] = data["on_error"].value
+        on_error = data.pop("on_error", ErrorAction.STOP_ALL)
+        if on_error != ErrorAction.STOP_ALL:  # Elide default
+            data["on_error"] = on_error.value
         if data.get("edge_merge_mode") == DEFAULT_EDGE_MERGE_MODE:  # Elide default
             del data["edge_merge_mode"]
         return data


### PR DESCRIPTION
These made things a little messier than necessary downstream.