### PR TITLE
☸️✍️ Allow `ephemeral-storage` settings on endpoint definitions

### DIFF
--- a/examples/endpoint-example.yaml
+++ b/examples/endpoint-example.yaml
@@ -24,8 +24,8 @@
         min: 0.1
         max: 1
       memory:
-        min: 50
-        max: 100
+        min: 50 # in MB
+        max: 100 # in MB
 
 - endpoint:
     name: accelerated-endpoint
@@ -52,7 +52,7 @@
     server-command: python run_server.py
     resources:
       memory:
-        max: 64
+        max: 64 # in MB
       ephemeral-storage:
-        min: 2048
-        max: 4096
+        min: 2048 # in MB
+        max: 4096 # in MB

--- a/examples/endpoint-example.yaml
+++ b/examples/endpoint-example.yaml
@@ -45,3 +45,14 @@
         operator: Equal
         value: value1
         effect: NoSchedule
+
+- endpoint:
+    name: ephemeral-storage-endpoint
+    image: python:3.9
+    server-command: python run_server.py
+    resources:
+      memory:
+        max: 64
+      ephemeral-storage:
+        min: 2048
+        max: 4096

--- a/tests/test_endpoint_parsing.py
+++ b/tests/test_endpoint_parsing.py
@@ -39,3 +39,12 @@ def test_tolerant_endpoint_parse(endpoint_config):
     assert toleration["operator"] == "Equal"
     assert toleration["value"] == "value1"
     assert toleration["effect"] == "NoSchedule"
+
+
+def test_ephemeral_storage_endpoint_parse(endpoint_config):
+    endpoint = endpoint_config.endpoints["ephemeral-storage-endpoint"]
+    assert "cpu" not in endpoint.resources
+    assert "min" not in endpoint.resources["memory"]
+    assert endpoint.resources["memory"]["max"] == 64
+    assert endpoint.resources["ephemeral-storage"]["min"] == 2048
+    assert endpoint.resources["ephemeral-storage"]["max"] == 4096

--- a/valohai_yaml/schema_data.py
+++ b/valohai_yaml/schema_data.py
@@ -148,6 +148,7 @@ register(
                 "properties": {
                     "cpu": {"$ref": "/schemas/workflow-resource-cpu"},
                     "devices": {"$ref": "/schemas/workflow-resource-devices"},
+                    "ephemeral-storage": {"$ref": "/schemas/workflow-resource-ephemeral-storage"},
                     "memory": {"$ref": "/schemas/workflow-resource-memory"},
                 },
                 "type": "object",
@@ -815,6 +816,15 @@ register(
         "$id": "https://valohai.com/schemas/workflow-resource-devices",
         "description": "Devices required e.g. 'nvidia.com/gpu: 1' for one NVIDIA GPU.",
         "patternProperties": {"^.+$": {"minimum": 1, "type": "number"}},
+        "type": "object",
+    },
+)
+register(
+    {
+        "$id": "https://valohai.com/schemas/workflow-resource-ephemeral-storage",
+        "additionalProperties": False,
+        "description": "Ephemeral storage requirements and limits in MB e.g. 100 is 100 MB.",
+        "properties": {"max": {"type": "integer"}, "min": {"type": "integer"}},
         "type": "object",
     },
 )


### PR DESCRIPTION
sometimes it can be useful to control [the ephemeral storage](https://kubernetes.io/docs/concepts/storage/ephemeral-storage/#requests-limits) per endpoint pod

- new optional `endpoint.resources.ephemeral-storage.min|max`
- added a few format comments to the main endpoint example as that is probably the first place people encounter these settings (schema info also describes them)