### PR TITLE
Skip linting of the step paramters if a node is referencing commit

### DIFF
--- a/examples/pipeline-with-param-referring-to-different-commit.yaml
+++ b/examples/pipeline-with-param-referring-to-different-commit.yaml
@@ -1,0 +1,15 @@
+- pipeline:
+    name: commit_pipe
+    edges: []
+    nodes:
+      - name: node_2
+        type: execution
+        step: some_step
+        commit: something-external
+
+    parameters:
+      - name: main_param
+        default: "value"
+        # The existence of this target can't be validated,
+        # since `node_2` refers to a commit we don't know of.
+        targets: [node_2.parameters.main_param]

--- a/valohai_yaml/objs/pipelines/pipeline_parameter.py
+++ b/valohai_yaml/objs/pipelines/pipeline_parameter.py
@@ -75,7 +75,7 @@ class PipelineParameter(Item):
                 node = node_map[target_node_name]
                 from valohai_yaml.objs import ExecutionNode
 
-                if isinstance(node, ExecutionNode):
+                if isinstance(node, ExecutionNode) and not node.commit:
                     step = steps[node.step]
                     if target_parameter_name not in step.parameters:
                         lint_result.add_error(


### PR DESCRIPTION
Linting such pipeline: 
```
- pipeline:
    name: commit_pipe
    nodes:
      - name: node_2
        type: execution
        step: some_step
        commit: <commit id>

    parameters:
    - name: main_param
      default: "value"
      targets: [node_2.parameters.main_param]
```

Will report an error as `some_step` step can't be found withing the steps in this .yaml.

Similarly how execution_node linting is skipped if commit is specified: https://github.com/valohai/valohai-yaml/blob/5f71bb7021557d5f4b64fe8e40fedb3ab482ec52/valohai_yaml/objs/pipelines/execution_node.py#L44
linting of a step parameters can also be skipped if a commit is specified.