### PR TITLE
Put 'autorestart' inside 'runtime_config'

### DIFF
--- a/examples/pipeline-with-autorestart-override.yaml
+++ b/examples/pipeline-with-autorestart-override.yaml
@@ -36,4 +36,11 @@
         override:
           # an override that does not mention autorestart keeps the step's value
           image: another/image
+      - name: remote-node
+        type: execution
+        commit: "library:some-library/train"
+        step: remote-train
+        override:
+          # the step lives in another config, so only the override can set this
+          autorestart: true
     edges: []

--- a/tests/test_pipeline_conversion.py
+++ b/tests/test_pipeline_conversion.py
@@ -165,10 +165,15 @@ def test_pipeline_conversion_autorestart_override(pipeline_with_autorestart_over
     templates = {node["name"]: node["template"] for node in result["nodes"]}
 
     # step says true, override says false
-    assert templates["train-node"]["autorestart"] is False
+    assert templates["train-node"]["runtime_config"]["autorestart"] is False
     # step does not say anything, override says true
-    assert templates["predict-node"]["autorestart"] is True
+    assert templates["predict-node"]["runtime_config"]["autorestart"] is True
     # task nodes are overridden the same way
-    assert templates["train-task-node"]["autorestart"] is False
+    assert templates["train-task-node"]["runtime_config"]["autorestart"] is False
     # an override that does not mention autorestart keeps the step's value
-    assert templates["inherit-node"]["autorestart"] is True
+    assert templates["inherit-node"]["runtime_config"]["autorestart"] is True
+    # a remote step is not available locally, so only the override folds in
+    assert templates["remote-node"]["runtime_config"]["autorestart"] is True
+
+    # the value only lives in runtime_config, not at the top level of the template
+    assert not any("autorestart" in template for template in templates.values())

--- a/valohai_yaml/pipelines/conversion.py
+++ b/valohai_yaml/pipelines/conversion.py
@@ -133,6 +133,12 @@ class PipelineConverter:
             # Just add in overrides and hope for the best...
             step_data = node.override.serialize() if node.override else {}
 
+        # Folded in after the override merge, so that a node can override the step's value.
+        # `None` means "not set anywhere"; an explicit `false` is kept.
+        autorestart = step_data.pop("autorestart", None)
+        if autorestart is not None:
+            step_data.setdefault("runtime_config", {})["autorestart"] = autorestart
+
         commit = node_commit or self.commit_identifier
 
         if not commit:  # pragma: no cover


### PR DESCRIPTION
Move step data to `runtime_config`—where Roi reads execution-specific settings from.
(This is similar to existing handling of `no_output_timeout`.)